### PR TITLE
feat: add a .devcontainer config for VSCode development

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,5 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.234.0/containers/typescript-node/.devcontainer/base.Dockerfile
+
+# Use the bullseye (Debian) image for compatibility with ARM/Apple Silicon.
+ARG VARIANT="18-bullseye"
+FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:0-${VARIANT}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,26 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.234.0/containers/typescript-node
+{
+	"name": "omshub",
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
+
+	"settings": {},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"dbaeumer.vscode-eslint",
+		"esbenp.prettier-vscode",
+		"ms-azuretools.vscode-docker"
+	],
+
+	// Application and Storybook.
+	"forwardPorts": [3000, 6006],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "./.devcontainer/scripts/start.sh",
+
+	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "node"
+}

--- a/.devcontainer/scripts/start.sh
+++ b/.devcontainer/scripts/start.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Performs setup tasks _after_ the .devcontainer Docker container is created.
+
+# Install Node dependencies.
+yarn install
+yarn build

--- a/README.md
+++ b/README.md
@@ -24,6 +24,20 @@ A website for Online Master's of Science (OMS) course reviews at Georgia Tech.
 
 ## Development
 
+#### Getting started (VSCode fast-path)
+
+This project includes a [.devcontainers](https://code.visualstudio.com/docs/remote/containers) configuration
+that can be used by VSCode to create a one-click development environment with Docker. The Docker container
+includes all of the dependencies you need to get started, forwards the NextJS and Storybook ports to your 
+local machine, and mounts the repository into the container so changes persist outside of Docker.
+
+To get started:
+
+1. Install the [Remote - Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
+   VSCode extension.
+2. Open the repository with VSCode. You should see a prompt on the bottom left of the screen to open the
+   project inside the container.
+
 #### Getting started
 
 Clone the repository and then run the following commands to build the NextJS application:


### PR DESCRIPTION
Adds a .devcontainer config to enable a fast-path local development
experience for VSCode users. This uses Docker to provision standard
development environments with all of the system dependencies required
for NodeJS development. The repository is mounted within the container,
so changes made to the code are reflected back on the host system.

It also configures VSCode with some sensible default extensions (ESLint,
Prettier, Docker).

See https://code.visualstudio.com/docs/remote/containers#_getting-started
for more information.