### PR TITLE
ci: add GitHub Actions workflow to lint and format changes

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,9 +1,17 @@
 {
-  "extends": ["plugin:storybook/recommended", "next/core-web-vitals", "eslint:recommended", "next", "prettier"],
-  "overrides": [{
-    "files": ["*.stories.@(ts|tsx|js|jsx|mjs|cjs)"],
-    "rules": {
-      "storybook/hierarchy-separator": "error"
-    }
-  }]
+	"extends": [
+		"plugin:storybook/recommended",
+		"next/core-web-vitals",
+		"eslint:recommended",
+		"next",
+		"prettier"
+	],
+	"overrides": [
+		{
+			"files": ["*.stories.@(ts|tsx|js|jsx|mjs|cjs)"],
+			"rules": {
+				"storybook/hierarchy-separator": "error"
+			}
+		}
+	]
 }

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,10 +1,9 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: "[BUG] "
+title: '[BUG] '
 labels: bug
 assignees: ''
-
 ---
 
 **Describe the bug**
@@ -12,6 +11,7 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
@@ -24,15 +24,17 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
+
+- OS: [e.g. iOS]
+- Browser [e.g. chrome, safari]
+- Version [e.g. 22]
 
 **Smartphone (please complete the following information):**
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
- - Version [e.g. 22]
+
+- Device: [e.g. iPhone6]
+- OS: [e.g. iOS8.1]
+- Browser [e.g. stock browser, safari]
+- Version [e.g. 22]
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,10 +1,9 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: "[FEATURE] "
+title: '[FEATURE] '
 labels: enhancement
 assignees: ''
-
 ---
 
 **Is your feature request related to a problem? Please describe.**

--- a/.github/workflows/ensure-prettier.sh
+++ b/.github/workflows/ensure-prettier.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Runs 'yarn prettier' and examines the git diff to determine whether Prettier wrote
+# any formatting changes. The script exits with an error code if changes are detected.
+# This is used by the GitHub Actions 'lint-and-format' job.
+
+set -euo pipefail
+
+yarn prettier
+
+if git status --porcelain | grep .; then
+    echo "Changes detected; did you format your code with 'yarn prettier'?"
+    exit 1;
+fi;

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,21 @@
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+      - dev
+
+jobs:
+  lint-and-format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: 'yarn'
+      - run: yarn install
+      - run: yarn lint
+      - run: ./.github/workflows/ensure-prettier.sh

--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,10 +1,10 @@
 const path = require('path')
 
 const buildEslintCommand = (filenames) =>
-  `next lint --fix --file ${filenames
-    .map((f) => path.relative(process.cwd(), f))
-    .join(' --file ')}`
+	`next lint --fix --file ${filenames
+		.map((f) => path.relative(process.cwd(), f))
+		.join(' --file ')}`
 
 module.exports = {
-  '*.{js,jsx,ts,tsx}': [buildEslintCommand],
+	'*.{js,jsx,ts,tsx}': [buildEslintCommand],
 }

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,12 +1,9 @@
 module.exports = {
-  "stories": [
-    "../src/**/*.stories.mdx",
-    "../src/**/*.stories.@(js|jsx|ts|tsx)"
-  ],
-  "addons": [
-    "@storybook/addon-links",
-    "@storybook/addon-essentials",
-    "@storybook/addon-interactions"
-  ],
-  "framework": "@storybook/react"
+	stories: ['../src/**/*.stories.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)'],
+	addons: [
+		'@storybook/addon-links',
+		'@storybook/addon-essentials',
+		'@storybook/addon-interactions',
+	],
+	framework: '@storybook/react',
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,8 @@
 {
-  "editor.defaultFormatter": "esbenp.prettier-vscode",
-  "editor.formatOnSave": true,
-  "editor.codeActionsOnSave": {
-    "source.fixAll": true,
-    "source.organizeImports": true
-  }
+	"editor.defaultFormatter": "esbenp.prettier-vscode",
+	"editor.formatOnSave": true,
+	"editor.codeActionsOnSave": {
+		"source.fixAll": true,
+		"source.organizeImports": true
+	}
 }

--- a/README.md
+++ b/README.md
@@ -24,6 +24,20 @@ A website for Online Master's of Science (OMS) course reviews at Georgia Tech.
 
 ## Development
 
+#### Getting started (VSCode fast-path)
+
+This project includes a [.devcontainers](https://code.visualstudio.com/docs/remote/containers) configuration
+that can be used by VSCode to create a one-click development environment with Docker. The Docker container
+includes all of the dependencies you need to get started, forwards the NextJS and Storybook ports to your
+local machine, and mounts the repository into the container so changes persist outside of Docker.
+
+To get started:
+
+1. Install the [Remote - Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
+   VSCode extension.
+2. Open the repository with VSCode. You should see a prompt on the bottom left of the screen to open the
+   project inside the container.
+
 #### Getting started
 
 Clone the repository and then run the following commands to build the NextJS application:

--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,4 @@
 /** @type {import('next').NextConfig} */
 module.exports = {
-  reactStrictMode: true,
-};
+	reactStrictMode: true,
+}

--- a/package.json
+++ b/package.json
@@ -1,70 +1,70 @@
 {
-  "name": "nextjs-with-typescript",
-  "version": "1.0.0",
-  "private": true,
-  "engines": {
-    "node": ">=14.0.0",
-    "yarn": ">=1.22.0",
-    "npm": "please-use-yarn"
-  },
-  "scripts": {
-    "dev": "next dev",
-    "build": "next build",
-    "start": "next start",
-    "lint": "next lint",
-    "prepare": "husky install",
-    "precommit": "lint-staged",
-    "prettier": "prettier --write .",
-    "post-update": "echo \"codesandbox preview only, need an update\" && yarn upgrade --latest",
-    "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook"
-  },
-  "dependencies": {
-    "@babel/core": "^7.0.0",
-    "@commitlint/cli": "^16.2.4",
-    "@commitlint/config-conventional": "^16.2.4",
-    "@emotion/cache": "^11.7.1",
-    "@emotion/react": "^11.9.0",
-    "@emotion/server": "^11.4.0",
-    "@emotion/styled": "^11.8.1",
-    "@mui/icons-material": "latest",
-    "@mui/material": "latest",
-    "commitizen": "^4.2.4",
-    "next": "latest",
-    "react": "latest",
-    "react-dom": "latest"
-  },
-  "devDependencies": {
-    "@storybook/addon-actions": "^6.4.22",
-    "@storybook/addon-essentials": "^6.4.22",
-    "@storybook/addon-interactions": "^6.4.22",
-    "@storybook/addon-links": "^6.4.22",
-    "@storybook/react": "^6.4.22",
-    "@storybook/testing-library": "^0.0.11",
-    "@types/node": "latest",
-    "@types/react": "latest",
-    "babel-loader": "^8.2.5",
-    "cz-conventional-changelog": "3.3.0",
-    "eslint": "latest",
-    "eslint-config-next": "latest",
-    "eslint-config-prettier": "^8.5.0",
-    "eslint-plugin-storybook": "^0.5.11",
-    "husky": "^8.0.1",
-    "lint-staged": "^12.4.1",
-    "prettier": "^2.6.2",
-    "typescript": "latest"
-  },
-  "config": {
-    "commitizen": {
-      "path": "./node_modules/cz-conventional-changelog"
-    }
-  },
-  "lint-staged": {
-    "*{js,jsx,ts,tsx}": [
-      "next lint"
-    ],
-    "*.{html,js,jsx,ts,tsx}": [
-      "prettier --write"
-    ]
-  }
+	"name": "nextjs-with-typescript",
+	"version": "1.0.0",
+	"private": true,
+	"engines": {
+		"node": ">=14.0.0",
+		"yarn": ">=1.22.0",
+		"npm": "please-use-yarn"
+	},
+	"scripts": {
+		"dev": "next dev",
+		"build": "next build",
+		"start": "next start",
+		"lint": "next lint",
+		"prepare": "husky install",
+		"precommit": "lint-staged",
+		"prettier": "prettier --write .",
+		"post-update": "echo \"codesandbox preview only, need an update\" && yarn upgrade --latest",
+		"storybook": "start-storybook -p 6006",
+		"build-storybook": "build-storybook"
+	},
+	"dependencies": {
+		"@babel/core": "^7.0.0",
+		"@commitlint/cli": "^16.2.4",
+		"@commitlint/config-conventional": "^16.2.4",
+		"@emotion/cache": "^11.7.1",
+		"@emotion/react": "^11.9.0",
+		"@emotion/server": "^11.4.0",
+		"@emotion/styled": "^11.8.1",
+		"@mui/icons-material": "latest",
+		"@mui/material": "latest",
+		"commitizen": "^4.2.4",
+		"next": "latest",
+		"react": "latest",
+		"react-dom": "latest"
+	},
+	"devDependencies": {
+		"@storybook/addon-actions": "^6.4.22",
+		"@storybook/addon-essentials": "^6.4.22",
+		"@storybook/addon-interactions": "^6.4.22",
+		"@storybook/addon-links": "^6.4.22",
+		"@storybook/react": "^6.4.22",
+		"@storybook/testing-library": "^0.0.11",
+		"@types/node": "latest",
+		"@types/react": "latest",
+		"babel-loader": "^8.2.5",
+		"cz-conventional-changelog": "3.3.0",
+		"eslint": "latest",
+		"eslint-config-next": "latest",
+		"eslint-config-prettier": "^8.5.0",
+		"eslint-plugin-storybook": "^0.5.11",
+		"husky": "^8.0.1",
+		"lint-staged": "^12.4.1",
+		"prettier": "^2.6.2",
+		"typescript": "latest"
+	},
+	"config": {
+		"commitizen": {
+			"path": "./node_modules/cz-conventional-changelog"
+		}
+	},
+	"lint-staged": {
+		"*{js,jsx,ts,tsx}": [
+			"next lint"
+		],
+		"*.{html,js,jsx,ts,tsx}": [
+			"prettier --write"
+		]
+	}
 }

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,33 +1,33 @@
 // pages/_app.tsx
 
-import * as React from 'react';
-import Head from 'next/head';
-import { AppProps } from 'next/app';
-import { ThemeProvider } from '@mui/material/styles';
-import CssBaseline from '@mui/material/CssBaseline';
-import { CacheProvider, EmotionCache } from '@emotion/react';
-import theme from '../src/theme';
-import createEmotionCache from '../src/createEmotionCache';
+import * as React from 'react'
+import Head from 'next/head'
+import { AppProps } from 'next/app'
+import { ThemeProvider } from '@mui/material/styles'
+import CssBaseline from '@mui/material/CssBaseline'
+import { CacheProvider, EmotionCache } from '@emotion/react'
+import theme from '../src/theme'
+import createEmotionCache from '../src/createEmotionCache'
 
 // Client-side cache, shared for the whole session of the user in the browser.
-const clientSideEmotionCache = createEmotionCache();
+const clientSideEmotionCache = createEmotionCache()
 
 interface MyAppProps extends AppProps {
-  emotionCache?: EmotionCache;
+	emotionCache?: EmotionCache
 }
 
 export default function MyApp(props: MyAppProps) {
-  const { Component, emotionCache = clientSideEmotionCache, pageProps } = props;
-  return (
-    <CacheProvider value={emotionCache}>
-      <Head>
-        <meta name="viewport" content="initial-scale=1, width=device-width" />
-      </Head>
-      <ThemeProvider theme={theme}>
-        {/* CssBaseline kickstart an elegant, consistent, and simple baseline to build upon. */}
-        <CssBaseline />
-        <Component {...pageProps} />
-      </ThemeProvider>
-    </CacheProvider>
-  );
+	const { Component, emotionCache = clientSideEmotionCache, pageProps } = props
+	return (
+		<CacheProvider value={emotionCache}>
+			<Head>
+				<meta name='viewport' content='initial-scale=1, width=device-width' />
+			</Head>
+			<ThemeProvider theme={theme}>
+				{/* CssBaseline kickstart an elegant, consistent, and simple baseline to build upon. */}
+				<CssBaseline />
+				<Component {...pageProps} />
+			</ThemeProvider>
+		</CacheProvider>
+	)
 }

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,88 +1,88 @@
-import * as React from 'react';
-import Document, { Html, Head, Main, NextScript } from 'next/document';
-import createEmotionServer from '@emotion/server/create-instance';
-import theme from '../src/theme';
-import createEmotionCache from '../src/createEmotionCache';
+import * as React from 'react'
+import Document, { Html, Head, Main, NextScript } from 'next/document'
+import createEmotionServer from '@emotion/server/create-instance'
+import theme from '../src/theme'
+import createEmotionCache from '../src/createEmotionCache'
 
 export default class MyDocument extends Document {
-  render() {
-    return (
-      <Html lang="en">
-        <Head>
-          {/* PWA primary color */}
-          <meta name="theme-color" content={theme.palette.primary.main} />
-          <link rel="shortcut icon" href="/static/favicon.ico" />
-          <link
-            rel="stylesheet"
-            href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap"
-          />
-          {/* Inject MUI styles first to match with the prepend: true configuration. */}
-          {(this.props as any).emotionStyleTags}
-        </Head>
-        <body>
-          <Main />
-          <NextScript />
-        </body>
-      </Html>
-    );
-  }
+	render() {
+		return (
+			<Html lang='en'>
+				<Head>
+					{/* PWA primary color */}
+					<meta name='theme-color' content={theme.palette.primary.main} />
+					<link rel='shortcut icon' href='/static/favicon.ico' />
+					<link
+						rel='stylesheet'
+						href='https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap'
+					/>
+					{/* Inject MUI styles first to match with the prepend: true configuration. */}
+					{(this.props as any).emotionStyleTags}
+				</Head>
+				<body>
+					<Main />
+					<NextScript />
+				</body>
+			</Html>
+		)
+	}
 }
 
 // `getInitialProps` belongs to `_document` (instead of `_app`),
 // it's compatible with static-site generation (SSG).
 MyDocument.getInitialProps = async (ctx) => {
-  // Resolution order
-  //
-  // On the server:
-  // 1. app.getInitialProps
-  // 2. page.getInitialProps
-  // 3. document.getInitialProps
-  // 4. app.render
-  // 5. page.render
-  // 6. document.render
-  //
-  // On the server with error:
-  // 1. document.getInitialProps
-  // 2. app.render
-  // 3. page.render
-  // 4. document.render
-  //
-  // On the client
-  // 1. app.getInitialProps
-  // 2. page.getInitialProps
-  // 3. app.render
-  // 4. page.render
+	// Resolution order
+	//
+	// On the server:
+	// 1. app.getInitialProps
+	// 2. page.getInitialProps
+	// 3. document.getInitialProps
+	// 4. app.render
+	// 5. page.render
+	// 6. document.render
+	//
+	// On the server with error:
+	// 1. document.getInitialProps
+	// 2. app.render
+	// 3. page.render
+	// 4. document.render
+	//
+	// On the client
+	// 1. app.getInitialProps
+	// 2. page.getInitialProps
+	// 3. app.render
+	// 4. page.render
 
-  const originalRenderPage = ctx.renderPage;
+	const originalRenderPage = ctx.renderPage
 
-  // You can consider sharing the same emotion cache between all the SSR requests to speed up performance.
-  // However, be aware that it can have global side effects.
-  const cache = createEmotionCache();
-  const { extractCriticalToChunks } = createEmotionServer(cache);
+	// You can consider sharing the same emotion cache between all the SSR requests to speed up performance.
+	// However, be aware that it can have global side effects.
+	const cache = createEmotionCache()
+	const { extractCriticalToChunks } = createEmotionServer(cache)
 
-  ctx.renderPage = () =>
-    originalRenderPage({
-      enhanceApp: (App: any) =>
-        function EnhanceApp(props) {
-          return <App emotionCache={cache} {...props} />;
-        },
-    });
+	ctx.renderPage = () =>
+		originalRenderPage({
+			enhanceApp: (App: any) =>
+				function EnhanceApp(props) {
+					return <App emotionCache={cache} {...props} />
+				},
+		})
 
-  const initialProps = await Document.getInitialProps(ctx);
-  // This is important. It prevents emotion to render invalid HTML.
-  // See https://github.com/mui/material-ui/issues/26561#issuecomment-855286153
-  const emotionStyles = extractCriticalToChunks(initialProps.html);
-  const emotionStyleTags = emotionStyles.styles.map((style) => (
-    <style
-      data-emotion={`${style.key} ${style.ids.join(' ')}`}
-      key={style.key}
-      // eslint-disable-next-line react/no-danger
-      dangerouslySetInnerHTML={{ __html: style.css }}
-    />
-  ));
+	const initialProps = await Document.getInitialProps(ctx)
+	// This is important. It prevents emotion to render invalid HTML.
+	// See https://github.com/mui/material-ui/issues/26561#issuecomment-855286153
+	const emotionStyles = extractCriticalToChunks(initialProps.html)
+	const emotionStyleTags = emotionStyles.styles.map((style) => (
+		<style
+			data-emotion={`${style.key} ${style.ids.join(' ')}`}
+			key={style.key}
+			// eslint-disable-next-line react/no-danger
+			dangerouslySetInnerHTML={{ __html: style.css }}
+		/>
+	))
 
-  return {
-    ...initialProps,
-    emotionStyleTags,
-  };
-};
+	return {
+		...initialProps,
+		emotionStyleTags,
+	}
+}

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -1,38 +1,38 @@
-import * as React from 'react';
-import type { NextPage } from 'next';
-import Container from '@mui/material/Container';
-import Typography from '@mui/material/Typography';
-import Box from '@mui/material/Box';
-import Button from '@mui/material/Button';
-import Link from '../src/Link';
-import ProTip from '../src/ProTip';
-import Copyright from '../src/Copyright';
+import * as React from 'react'
+import type { NextPage } from 'next'
+import Container from '@mui/material/Container'
+import Typography from '@mui/material/Typography'
+import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
+import Link from '../src/Link'
+import ProTip from '../src/ProTip'
+import Copyright from '../src/Copyright'
 
 const About: NextPage = () => {
-  return (
-    <Container maxWidth="lg">
-      <Box
-        sx={{
-          my: 4,
-          display: 'flex',
-          flexDirection: 'column',
-          justifyContent: 'center',
-          alignItems: 'center',
-        }}
-      >
-        <Typography variant="h4" component="h1" gutterBottom>
-          MUI v5 + Next.js with TypeScript example
-        </Typography>
-        <Box maxWidth="sm">
-          <Button variant="contained" component={Link} noLinkStyle href="/">
-            Go to the home page
-          </Button>
-        </Box>
-        <ProTip />
-        <Copyright />
-      </Box>
-    </Container>
-  );
-};
+	return (
+		<Container maxWidth='lg'>
+			<Box
+				sx={{
+					my: 4,
+					display: 'flex',
+					flexDirection: 'column',
+					justifyContent: 'center',
+					alignItems: 'center',
+				}}
+			>
+				<Typography variant='h4' component='h1' gutterBottom>
+					MUI v5 + Next.js with TypeScript example
+				</Typography>
+				<Box maxWidth='sm'>
+					<Button variant='contained' component={Link} noLinkStyle href='/'>
+						Go to the home page
+					</Button>
+				</Box>
+				<ProTip />
+				<Copyright />
+			</Box>
+		</Container>
+	)
+}
 
-export default About;
+export default About

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,35 +1,35 @@
-import * as React from 'react';
-import type { NextPage } from 'next';
-import Container from '@mui/material/Container';
-import Typography from '@mui/material/Typography';
-import Box from '@mui/material/Box';
-import Link from '../src/Link';
-import ProTip from '../src/ProTip';
-import Copyright from '../src/Copyright';
+import * as React from 'react'
+import type { NextPage } from 'next'
+import Container from '@mui/material/Container'
+import Typography from '@mui/material/Typography'
+import Box from '@mui/material/Box'
+import Link from '../src/Link'
+import ProTip from '../src/ProTip'
+import Copyright from '../src/Copyright'
 
 const Home: NextPage = () => {
-  return (
-    <Container maxWidth="lg">
-      <Box
-        sx={{
-          my: 4,
-          display: 'flex',
-          flexDirection: 'column',
-          justifyContent: 'center',
-          alignItems: 'center',
-        }}
-      >
-        <Typography variant="h4" component="h1" gutterBottom>
-          MUI v5 + Next.js with TypeScript example
-        </Typography>
-        <Link href="/about" color="secondary">
-          Go to the about page
-        </Link>
-        <ProTip />
-        <Copyright />
-      </Box>
-    </Container>
-  );
-};
+	return (
+		<Container maxWidth='lg'>
+			<Box
+				sx={{
+					my: 4,
+					display: 'flex',
+					flexDirection: 'column',
+					justifyContent: 'center',
+					alignItems: 'center',
+				}}
+			>
+				<Typography variant='h4' component='h1' gutterBottom>
+					MUI v5 + Next.js with TypeScript example
+				</Typography>
+				<Link href='/about' color='secondary'>
+					Go to the about page
+				</Link>
+				<ProTip />
+				<Copyright />
+			</Box>
+		</Container>
+	)
+}
 
-export default Home;
+export default Home

--- a/src/Copyright.tsx
+++ b/src/Copyright.tsx
@@ -1,15 +1,15 @@
-import * as React from 'react';
-import Typography from '@mui/material/Typography';
-import MuiLink from '@mui/material/Link';
+import * as React from 'react'
+import Typography from '@mui/material/Typography'
+import MuiLink from '@mui/material/Link'
 
 export default function Copyright() {
-  return (
-    <Typography variant="body2" color="text.secondary" align="center">
-      {'Copyright © '}
-      <MuiLink color="inherit" href="https://mui.com/">
-        Your Website
-      </MuiLink>{' '}
-      {new Date().getFullYear()}.
-    </Typography>
-  );
+	return (
+		<Typography variant='body2' color='text.secondary' align='center'>
+			{'Copyright © '}
+			<MuiLink color='inherit' href='https://mui.com/'>
+				Your Website
+			</MuiLink>{' '}
+			{new Date().getFullYear()}.
+		</Typography>
+	)
 }

--- a/src/Link.tsx
+++ b/src/Link.tsx
@@ -1,102 +1,122 @@
-import * as React from 'react';
-import clsx from 'clsx';
-import { useRouter } from 'next/router';
-import NextLink, { LinkProps as NextLinkProps } from 'next/link';
-import MuiLink, { LinkProps as MuiLinkProps } from '@mui/material/Link';
-import { styled } from '@mui/material/styles';
+import MuiLink, { LinkProps as MuiLinkProps } from '@mui/material/Link'
+import { styled } from '@mui/material/styles'
+import clsx from 'clsx'
+import NextLink, { LinkProps as NextLinkProps } from 'next/link'
+import { useRouter } from 'next/router'
+import * as React from 'react'
 
 // Add support for the sx prop for consistency with the other branches.
-const Anchor = styled('a')({});
+const Anchor = styled('a')({})
 
 interface NextLinkComposedProps
-  extends Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'href'>,
-  Omit<NextLinkProps, 'href' | 'as' | 'onClick' | 'onMouseEnter'>{
-    to: NextLinkProps['href'];
-  linkAs?: NextLinkProps['as'];
+	extends Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'href'>,
+		Omit<NextLinkProps, 'href' | 'as' | 'onClick' | 'onMouseEnter'> {
+	to: NextLinkProps['href']
+	linkAs?: NextLinkProps['as']
 }
 
-export const NextLinkComposed = React.forwardRef<HTMLAnchorElement, NextLinkComposedProps>(
-  function NextLinkComposed(props, ref) {
-    const { to, linkAs, replace, scroll, shallow, prefetch, locale, ...other } = props;
+export const NextLinkComposed = React.forwardRef<
+	HTMLAnchorElement,
+	NextLinkComposedProps
+>(function NextLinkComposed(props, ref) {
+	const { to, linkAs, replace, scroll, shallow, prefetch, locale, ...other } =
+		props
 
-    return (
-      <NextLink
-        href={to}
-        prefetch={prefetch}
-        as={linkAs}
-        replace={replace}
-        scroll={scroll}
-        shallow={shallow}
-        passHref
-        locale={locale}
-      >
-        <Anchor ref={ref} {...other} />
-      </NextLink>
-    );
-  },
-);
+	return (
+		<NextLink
+			href={to}
+			prefetch={prefetch}
+			as={linkAs}
+			replace={replace}
+			scroll={scroll}
+			shallow={shallow}
+			passHref
+			locale={locale}
+		>
+			<Anchor ref={ref} {...other} />
+		</NextLink>
+	)
+})
 
 export type LinkProps = {
-  activeClassName?: string;
-  as?: NextLinkProps['as'];
-  href: NextLinkProps['href'];
-  linkAs?: NextLinkProps['as']; // Useful when the as prop is shallow by styled().
-  noLinkStyle?: boolean;
+	activeClassName?: string
+	as?: NextLinkProps['as']
+	href: NextLinkProps['href']
+	linkAs?: NextLinkProps['as'] // Useful when the as prop is shallow by styled().
+	noLinkStyle?: boolean
 } & Omit<NextLinkComposedProps, 'to' | 'linkAs' | 'href'> &
-  Omit<MuiLinkProps, 'href'>;
+	Omit<MuiLinkProps, 'href'>
 
 // A styled version of the Next.js Link component:
 // https://nextjs.org/docs/api-reference/next/link
-const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(function Link(props, ref) {
-  const {
-    activeClassName = 'active',
-    as,
-    className: classNameProps,
-    href,
-    linkAs: linkAsProp,
-    locale,
-    noLinkStyle,
-    prefetch,
-    replace,
-    role, // Link don't have roles.
-    scroll,
-    shallow,
-    ...other
-  } = props;
+const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(function Link(
+	props,
+	ref
+) {
+	const {
+		activeClassName = 'active',
+		as,
+		className: classNameProps,
+		href,
+		linkAs: linkAsProp,
+		locale,
+		noLinkStyle,
+		prefetch,
+		replace,
+		scroll,
+		shallow,
+		...other
+	} = props
 
-  const router = useRouter();
-  const pathname = typeof href === 'string' ? href : href.pathname;
-  const className = clsx(classNameProps, {
-    [activeClassName]: router.pathname === pathname && activeClassName,
-  });
+	const router = useRouter()
+	const pathname = typeof href === 'string' ? href : href.pathname
+	const className = clsx(classNameProps, {
+		[activeClassName]: router.pathname === pathname && activeClassName,
+	})
 
-  const isExternal =
-    typeof href === 'string' && (href.indexOf('http') === 0 || href.indexOf('mailto:') === 0);
+	const isExternal =
+		typeof href === 'string' &&
+		(href.indexOf('http') === 0 || href.indexOf('mailto:') === 0)
 
-  if (isExternal) {
-    if (noLinkStyle) {
-      return <Anchor className={className} href={href} ref={ref} {...other} />;
-    }
+	if (isExternal) {
+		if (noLinkStyle) {
+			return <Anchor className={className} href={href} ref={ref} {...other} />
+		}
 
-    return <MuiLink className={className} href={href} ref={ref} {...other} />;
-  }
+		return <MuiLink className={className} href={href} ref={ref} {...other} />
+	}
 
-  const linkAs = linkAsProp || as;
-  const nextjsProps = { to: href, linkAs, replace, scroll, shallow, prefetch, locale };
+	const linkAs = linkAsProp || as
+	const nextjsProps = {
+		to: href,
+		linkAs,
+		replace,
+		scroll,
+		shallow,
+		prefetch,
+		locale,
+	}
 
-  if (noLinkStyle) {
-    return <NextLinkComposed className={className} ref={ref} {...nextjsProps} {...other} />;
-  }
+	if (noLinkStyle) {
+		return (
+			<NextLinkComposed
+				className={className}
+				ref={ref}
+				{...nextjsProps}
+				{...other}
+			/>
+		)
+	}
 
-  return (
-    <MuiLink
-      component={NextLinkComposed}
-      className={className}
-      ref={ref}
-      {...nextjsProps}
-      {...other}
-    />
-  );
-});
+	return (
+		<MuiLink
+			component={NextLinkComposed}
+			className={className}
+			ref={ref}
+			{...nextjsProps}
+			{...other}
+		/>
+	)
+})
 
-export default Link;
+export default Link

--- a/src/ProTip.tsx
+++ b/src/ProTip.tsx
@@ -1,22 +1,25 @@
-import * as React from 'react';
-import Link from '@mui/material/Link';
-import SvgIcon, { SvgIconProps } from '@mui/material/SvgIcon';
-import Typography from '@mui/material/Typography';
+import * as React from 'react'
+import Link from '@mui/material/Link'
+import SvgIcon, { SvgIconProps } from '@mui/material/SvgIcon'
+import Typography from '@mui/material/Typography'
 
 function LightBulbIcon(props: SvgIconProps) {
-  return (
-    <SvgIcon {...props}>
-      <path d="M9 21c0 .55.45 1 1 1h4c.55 0 1-.45 1-1v-1H9v1zm3-19C8.14 2 5 5.14 5 9c0 2.38 1.19 4.47 3 5.74V17c0 .55.45 1 1 1h6c.55 0 1-.45 1-1v-2.26c1.81-1.27 3-3.36 3-5.74 0-3.86-3.14-7-7-7zm2.85 11.1l-.85.6V16h-4v-2.3l-.85-.6C7.8 12.16 7 10.63 7 9c0-2.76 2.24-5 5-5s5 2.24 5 5c0 1.63-.8 3.16-2.15 4.1z" />
-    </SvgIcon>
-  );
+	return (
+		<SvgIcon {...props}>
+			<path d='M9 21c0 .55.45 1 1 1h4c.55 0 1-.45 1-1v-1H9v1zm3-19C8.14 2 5 5.14 5 9c0 2.38 1.19 4.47 3 5.74V17c0 .55.45 1 1 1h6c.55 0 1-.45 1-1v-2.26c1.81-1.27 3-3.36 3-5.74 0-3.86-3.14-7-7-7zm2.85 11.1l-.85.6V16h-4v-2.3l-.85-.6C7.8 12.16 7 10.63 7 9c0-2.76 2.24-5 5-5s5 2.24 5 5c0 1.63-.8 3.16-2.15 4.1z' />
+		</SvgIcon>
+	)
 }
 
 export default function ProTip() {
-  return (
-    <Typography sx={{ mt: 6, mb: 3 }} color="text.secondary">
-      <LightBulbIcon sx={{ mr: 1, verticalAlign: 'middle' }} />
-      Pro tip: See more <Link href="https://mui.com/getting-started/templates/">templates</Link> on
-      the MUI documentation.
-    </Typography>
-  );
+	return (
+		<Typography sx={{ mt: 6, mb: 3 }} color='text.secondary'>
+			<LightBulbIcon sx={{ mr: 1, verticalAlign: 'middle' }} />
+			Pro tip: See more{' '}
+			<Link href='https://mui.com/getting-started/templates/'>
+				templates
+			</Link>{' '}
+			on the MUI documentation.
+		</Typography>
+	)
 }

--- a/src/createEmotionCache.ts
+++ b/src/createEmotionCache.ts
@@ -1,7 +1,7 @@
-import createCache from '@emotion/cache';
+import createCache from '@emotion/cache'
 
 // prepend: true moves MUI styles to the top of the <head> so they're loaded first.
 // It allows developers to easily override MUI styles with other styling solutions, like CSS modules.
 export default function createEmotionCache() {
-  return createCache({ key: 'css', prepend: true });
+	return createCache({ key: 'css', prepend: true })
 }

--- a/src/stories/Button.stories.tsx
+++ b/src/stories/Button.stories.tsx
@@ -1,41 +1,41 @@
-import React from 'react';
-import { ComponentStory, ComponentMeta } from '@storybook/react';
+import React from 'react'
+import { ComponentStory, ComponentMeta } from '@storybook/react'
 
-import { Button } from './Button';
+import { Button } from './Button'
 
 // More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 export default {
-  title: 'Example/Button',
-  component: Button,
-  // More on argTypes: https://storybook.js.org/docs/react/api/argtypes
-  argTypes: {
-    backgroundColor: { control: 'color' },
-  },
-} as ComponentMeta<typeof Button>;
+	title: 'Example/Button',
+	component: Button,
+	// More on argTypes: https://storybook.js.org/docs/react/api/argtypes
+	argTypes: {
+		backgroundColor: { control: 'color' },
+	},
+} as ComponentMeta<typeof Button>
 
 // More on component templates: https://storybook.js.org/docs/react/writing-stories/introduction#using-args
-const Template: ComponentStory<typeof Button> = (args) => <Button {...args} />;
+const Template: ComponentStory<typeof Button> = (args) => <Button {...args} />
 
-export const Primary = Template.bind({});
+export const Primary = Template.bind({})
 // More on args: https://storybook.js.org/docs/react/writing-stories/args
 Primary.args = {
-  primary: true,
-  label: 'Button',
-};
+	primary: true,
+	label: 'Button',
+}
 
-export const Secondary = Template.bind({});
+export const Secondary = Template.bind({})
 Secondary.args = {
-  label: 'Button',
-};
+	label: 'Button',
+}
 
-export const Large = Template.bind({});
+export const Large = Template.bind({})
 Large.args = {
-  size: 'large',
-  label: 'Button',
-};
+	size: 'large',
+	label: 'Button',
+}
 
-export const Small = Template.bind({});
+export const Small = Template.bind({})
 Small.args = {
-  size: 'small',
-  label: 'Button',
-};
+	size: 'small',
+	label: 'Button',
+}

--- a/src/stories/Button.tsx
+++ b/src/stories/Button.tsx
@@ -1,48 +1,52 @@
-import React from 'react';
-import './button.css';
+import React from 'react'
+import './button.css'
 
 interface ButtonProps {
-  /**
-   * Is this the principal call to action on the page?
-   */
-  primary?: boolean;
-  /**
-   * What background color to use
-   */
-  backgroundColor?: string;
-  /**
-   * How large should the button be?
-   */
-  size?: 'small' | 'medium' | 'large';
-  /**
-   * Button contents
-   */
-  label: string;
-  /**
-   * Optional click handler
-   */
-  onClick?: () => void;
+	/**
+	 * Is this the principal call to action on the page?
+	 */
+	primary?: boolean
+	/**
+	 * What background color to use
+	 */
+	backgroundColor?: string
+	/**
+	 * How large should the button be?
+	 */
+	size?: 'small' | 'medium' | 'large'
+	/**
+	 * Button contents
+	 */
+	label: string
+	/**
+	 * Optional click handler
+	 */
+	onClick?: () => void
 }
 
 /**
  * Primary UI component for user interaction
  */
 export const Button = ({
-  primary = false,
-  size = 'medium',
-  backgroundColor,
-  label,
-  ...props
+	primary = false,
+	size = 'medium',
+	backgroundColor,
+	label,
+	...props
 }: ButtonProps) => {
-  const mode = primary ? 'storybook-button--primary' : 'storybook-button--secondary';
-  return (
-    <button
-      type="button"
-      className={['storybook-button', `storybook-button--${size}`, mode].join(' ')}
-      style={{ backgroundColor }}
-      {...props}
-    >
-      {label}
-    </button>
-  );
-};
+	const mode = primary
+		? 'storybook-button--primary'
+		: 'storybook-button--secondary'
+	return (
+		<button
+			type='button'
+			className={['storybook-button', `storybook-button--${size}`, mode].join(
+				' '
+			)}
+			style={{ backgroundColor }}
+			{...props}
+		>
+			{label}
+		</button>
+	)
+}

--- a/src/stories/Header.stories.tsx
+++ b/src/stories/Header.stories.tsx
@@ -1,25 +1,25 @@
-import React from 'react';
-import { ComponentStory, ComponentMeta } from '@storybook/react';
+import React from 'react'
+import { ComponentStory, ComponentMeta } from '@storybook/react'
 
-import { Header } from './Header';
+import { Header } from './Header'
 
 export default {
-  title: 'Example/Header',
-  component: Header,
-  parameters: {
-    // More on Story layout: https://storybook.js.org/docs/react/configure/story-layout
-    layout: 'fullscreen',
-  },
-} as ComponentMeta<typeof Header>;
+	title: 'Example/Header',
+	component: Header,
+	parameters: {
+		// More on Story layout: https://storybook.js.org/docs/react/configure/story-layout
+		layout: 'fullscreen',
+	},
+} as ComponentMeta<typeof Header>
 
-const Template: ComponentStory<typeof Header> = (args) => <Header {...args} />;
+const Template: ComponentStory<typeof Header> = (args) => <Header {...args} />
 
-export const LoggedIn = Template.bind({});
+export const LoggedIn = Template.bind({})
 LoggedIn.args = {
-  user: {
-    name: 'Jane Doe',
-  },
-};
+	user: {
+		name: 'Jane Doe',
+	},
+}
 
-export const LoggedOut = Template.bind({});
-LoggedOut.args = {};
+export const LoggedOut = Template.bind({})
+LoggedOut.args = {}

--- a/src/stories/Header.tsx
+++ b/src/stories/Header.tsx
@@ -1,56 +1,71 @@
-import React from 'react';
+import React from 'react'
 
-import { Button } from './Button';
-import './header.css';
+import { Button } from './Button'
+import './header.css'
 
 type User = {
-  name: string;
-};
-
-interface HeaderProps {
-  user?: User;
-  onLogin: () => void;
-  onLogout: () => void;
-  onCreateAccount: () => void;
+	name: string
 }
 
-export const Header = ({ user, onLogin, onLogout, onCreateAccount }: HeaderProps) => (
-  <header>
-    <div className="wrapper">
-      <div>
-        <svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
-          <g fill="none" fillRule="evenodd">
-            <path
-              d="M10 0h12a10 10 0 0110 10v12a10 10 0 01-10 10H10A10 10 0 010 22V10A10 10 0 0110 0z"
-              fill="#FFF"
-            />
-            <path
-              d="M5.3 10.6l10.4 6v11.1l-10.4-6v-11zm11.4-6.2l9.7 5.5-9.7 5.6V4.4z"
-              fill="#555AB9"
-            />
-            <path
-              d="M27.2 10.6v11.2l-10.5 6V16.5l10.5-6zM15.7 4.4v11L6 10l9.7-5.5z"
-              fill="#91BAF8"
-            />
-          </g>
-        </svg>
-        <h1>Acme</h1>
-      </div>
-      <div>
-        {user ? (
-          <>
-            <span className="welcome">
-              Welcome, <b>{user.name}</b>!
-            </span>
-            <Button size="small" onClick={onLogout} label="Log out" />
-          </>
-        ) : (
-          <>
-            <Button size="small" onClick={onLogin} label="Log in" />
-            <Button primary size="small" onClick={onCreateAccount} label="Sign up" />
-          </>
-        )}
-      </div>
-    </div>
-  </header>
-);
+interface HeaderProps {
+	user?: User
+	onLogin: () => void
+	onLogout: () => void
+	onCreateAccount: () => void
+}
+
+export const Header = ({
+	user,
+	onLogin,
+	onLogout,
+	onCreateAccount,
+}: HeaderProps) => (
+	<header>
+		<div className='wrapper'>
+			<div>
+				<svg
+					width='32'
+					height='32'
+					viewBox='0 0 32 32'
+					xmlns='http://www.w3.org/2000/svg'
+				>
+					<g fill='none' fillRule='evenodd'>
+						<path
+							d='M10 0h12a10 10 0 0110 10v12a10 10 0 01-10 10H10A10 10 0 010 22V10A10 10 0 0110 0z'
+							fill='#FFF'
+						/>
+						<path
+							d='M5.3 10.6l10.4 6v11.1l-10.4-6v-11zm11.4-6.2l9.7 5.5-9.7 5.6V4.4z'
+							fill='#555AB9'
+						/>
+						<path
+							d='M27.2 10.6v11.2l-10.5 6V16.5l10.5-6zM15.7 4.4v11L6 10l9.7-5.5z'
+							fill='#91BAF8'
+						/>
+					</g>
+				</svg>
+				<h1>Acme</h1>
+			</div>
+			<div>
+				{user ? (
+					<>
+						<span className='welcome'>
+							Welcome, <b>{user.name}</b>!
+						</span>
+						<Button size='small' onClick={onLogout} label='Log out' />
+					</>
+				) : (
+					<>
+						<Button size='small' onClick={onLogin} label='Log in' />
+						<Button
+							primary
+							size='small'
+							onClick={onCreateAccount}
+							label='Sign up'
+						/>
+					</>
+				)}
+			</div>
+		</div>
+	</header>
+)

--- a/src/stories/Introduction.stories.mdx
+++ b/src/stories/Introduction.stories.mdx
@@ -1,14 +1,14 @@
-import { Meta } from '@storybook/addon-docs';
-import Code from './assets/code-brackets.svg';
-import Colors from './assets/colors.svg';
-import Comments from './assets/comments.svg';
-import Direction from './assets/direction.svg';
-import Flow from './assets/flow.svg';
-import Plugin from './assets/plugin.svg';
-import Repo from './assets/repo.svg';
-import StackAlt from './assets/stackalt.svg';
+import { Meta } from '@storybook/addon-docs'
+import Code from './assets/code-brackets.svg'
+import Colors from './assets/colors.svg'
+import Comments from './assets/comments.svg'
+import Direction from './assets/direction.svg'
+import Flow from './assets/flow.svg'
+import Plugin from './assets/plugin.svg'
+import Repo from './assets/repo.svg'
+import StackAlt from './assets/stackalt.svg'
 
-<Meta title="Example/Introduction" />
+<Meta title='Example/Introduction' />
 
 <style>{`
   .subheading {
@@ -123,89 +123,97 @@ Browse example stories now by navigating to them in the sidebar.
 View their code in the `src/stories` directory to learn how they work.
 We recommend building UIs with a [**component-driven**](https://componentdriven.org) process starting with atomic components and ending with pages.
 
-<div className="subheading">Configure</div>
+<div className='subheading'>Configure</div>
 
-<div className="link-list">
-  <a
-    className="link-item"
-    href="https://storybook.js.org/docs/react/addons/addon-types"
-    target="_blank"
-  >
-    <img src={Plugin} alt="plugin" />
-    <span>
-      <strong>Presets for popular tools</strong>
-      Easy setup for TypeScript, SCSS and more.
-    </span>
-  </a>
-  <a
-    className="link-item"
-    href="https://storybook.js.org/docs/react/configure/webpack"
-    target="_blank"
-  >
-    <img src={StackAlt} alt="Build" />
-    <span>
-      <strong>Build configuration</strong>
-      How to customize webpack and Babel
-    </span>
-  </a>
-  <a
-    className="link-item"
-    href="https://storybook.js.org/docs/react/configure/styling-and-css"
-    target="_blank"
-  >
-    <img src={Colors} alt="colors" />
-    <span>
-      <strong>Styling</strong>
-      How to load and configure CSS libraries
-    </span>
-  </a>
-  <a
-    className="link-item"
-    href="https://storybook.js.org/docs/react/get-started/setup#configure-storybook-for-your-stack"
-    target="_blank"
-  >
-    <img src={Flow} alt="flow" />
-    <span>
-      <strong>Data</strong>
-      Providers and mocking for data libraries
-    </span>
-  </a>
+<div className='link-list'>
+	<a
+		className='link-item'
+		href='https://storybook.js.org/docs/react/addons/addon-types'
+		target='_blank'
+	>
+		<img src={Plugin} alt='plugin' />
+		<span>
+			<strong>Presets for popular tools</strong>
+			Easy setup for TypeScript, SCSS and more.
+		</span>
+	</a>
+	<a
+		className='link-item'
+		href='https://storybook.js.org/docs/react/configure/webpack'
+		target='_blank'
+	>
+		<img src={StackAlt} alt='Build' />
+		<span>
+			<strong>Build configuration</strong>
+			How to customize webpack and Babel
+		</span>
+	</a>
+	<a
+		className='link-item'
+		href='https://storybook.js.org/docs/react/configure/styling-and-css'
+		target='_blank'
+	>
+		<img src={Colors} alt='colors' />
+		<span>
+			<strong>Styling</strong>
+			How to load and configure CSS libraries
+		</span>
+	</a>
+	<a
+		className='link-item'
+		href='https://storybook.js.org/docs/react/get-started/setup#configure-storybook-for-your-stack'
+		target='_blank'
+	>
+		<img src={Flow} alt='flow' />
+		<span>
+			<strong>Data</strong>
+			Providers and mocking for data libraries
+		</span>
+	</a>
 </div>
 
-<div className="subheading">Learn</div>
+<div className='subheading'>Learn</div>
 
-<div className="link-list">
-  <a className="link-item" href="https://storybook.js.org/docs" target="_blank">
-    <img src={Repo} alt="repo" />
-    <span>
-      <strong>Storybook documentation</strong>
-      Configure, customize, and extend
-    </span>
-  </a>
-  <a className="link-item" href="https://storybook.js.org/tutorials/" target="_blank">
-    <img src={Direction} alt="direction" />
-    <span>
-      <strong>In-depth guides</strong>
-      Best practices from leading teams
-    </span>
-  </a>
-  <a className="link-item" href="https://github.com/storybookjs/storybook" target="_blank">
-    <img src={Code} alt="code" />
-    <span>
-      <strong>GitHub project</strong>
-      View the source and add issues
-    </span>
-  </a>
-  <a className="link-item" href="https://discord.gg/storybook" target="_blank">
-    <img src={Comments} alt="comments" />
-    <span>
-      <strong>Discord chat</strong>
-      Chat with maintainers and the community
-    </span>
-  </a>
+<div className='link-list'>
+	<a className='link-item' href='https://storybook.js.org/docs' target='_blank'>
+		<img src={Repo} alt='repo' />
+		<span>
+			<strong>Storybook documentation</strong>
+			Configure, customize, and extend
+		</span>
+	</a>
+	<a
+		className='link-item'
+		href='https://storybook.js.org/tutorials/'
+		target='_blank'
+	>
+		<img src={Direction} alt='direction' />
+		<span>
+			<strong>In-depth guides</strong>
+			Best practices from leading teams
+		</span>
+	</a>
+	<a
+		className='link-item'
+		href='https://github.com/storybookjs/storybook'
+		target='_blank'
+	>
+		<img src={Code} alt='code' />
+		<span>
+			<strong>GitHub project</strong>
+			View the source and add issues
+		</span>
+	</a>
+	<a className='link-item' href='https://discord.gg/storybook' target='_blank'>
+		<img src={Comments} alt='comments' />
+		<span>
+			<strong>Discord chat</strong>
+			Chat with maintainers and the community
+		</span>
+	</a>
 </div>
 
-<div className="tip-wrapper">
-  <span className="tip">Tip</span>Edit the Markdown in{' '}
-  <code>src/stories/Introduction.stories.mdx</code>
+<div className='tip-wrapper'>
+	<span className='tip'>Tip</span>Edit the Markdown in{' '}
+	<code>src/stories/Introduction.stories.mdx</code>
 </div>

--- a/src/stories/Page.stories.tsx
+++ b/src/stories/Page.stories.tsx
@@ -1,26 +1,26 @@
-import React from 'react';
-import { ComponentStory, ComponentMeta } from '@storybook/react';
-import { within, userEvent } from '@storybook/testing-library';
-import { Page } from './Page';
+import React from 'react'
+import { ComponentStory, ComponentMeta } from '@storybook/react'
+import { within, userEvent } from '@storybook/testing-library'
+import { Page } from './Page'
 
 export default {
-  title: 'Example/Page',
-  component: Page,
-  parameters: {
-    // More on Story layout: https://storybook.js.org/docs/react/configure/story-layout
-    layout: 'fullscreen',
-  },
-} as ComponentMeta<typeof Page>;
+	title: 'Example/Page',
+	component: Page,
+	parameters: {
+		// More on Story layout: https://storybook.js.org/docs/react/configure/story-layout
+		layout: 'fullscreen',
+	},
+} as ComponentMeta<typeof Page>
 
-const Template: ComponentStory<typeof Page> = (args) => <Page {...args} />;
+const Template: ComponentStory<typeof Page> = (args) => <Page {...args} />
 
-export const LoggedOut = Template.bind({});
+export const LoggedOut = Template.bind({})
 
-export const LoggedIn = Template.bind({});
+export const LoggedIn = Template.bind({})
 
 // More on interaction testing: https://storybook.js.org/docs/react/writing-tests/interaction-testing
 LoggedIn.play = async ({ canvasElement }) => {
-  const canvas = within(canvasElement);
-  const loginButton = await canvas.getByRole('button', { name: /Log in/i });
-  await userEvent.click(loginButton);
-};
+	const canvas = within(canvasElement)
+	const loginButton = await canvas.getByRole('button', { name: /Log in/i })
+	await userEvent.click(loginButton)
+}

--- a/src/stories/Page.tsx
+++ b/src/stories/Page.tsx
@@ -1,73 +1,91 @@
-import React from 'react';
-import { Header } from './Header';
-import './page.css';
-
+import React from 'react'
+import { Header } from './Header'
+import './page.css'
 
 type User = {
-  name: string;
-};
+	name: string
+}
 
 export const Page: React.VFC = () => {
-  const [user, setUser] = React.useState<User>();
+	const [user, setUser] = React.useState<User>()
 
-  return (
-    <article>
-      <Header
-        user={user}
-        onLogin={() => setUser({ name: 'Jane Doe' })}
-        onLogout={() => setUser(undefined)}
-        onCreateAccount={() => setUser({ name: 'Jane Doe' })}
-      />
+	return (
+		<article>
+			<Header
+				user={user}
+				onLogin={() => setUser({ name: 'Jane Doe' })}
+				onLogout={() => setUser(undefined)}
+				onCreateAccount={() => setUser({ name: 'Jane Doe' })}
+			/>
 
-      <section>
-        <h2>Pages in Storybook</h2>
-        <p>
-          We recommend building UIs with a{' '}
-          <a href="https://componentdriven.org" target="_blank" rel="noopener noreferrer">
-            <strong>component-driven</strong>
-          </a>{' '}
-          process starting with atomic components and ending with pages.
-        </p>
-        <p>
-          Render pages with mock data. This makes it easy to build and review page states without
-          needing to navigate to them in your app. Here are some handy patterns for managing page
-          data in Storybook:
-        </p>
-        <ul>
-          <li>
-            Use a higher-level connected component. Storybook helps you compose such data from the
-            {"args"} of child component stories
-          </li>
-          <li>
-            Assemble data in the page component from your services. You can mock these services out
-            using Storybook.
-          </li>
-        </ul>
-        <p>
-          Get a guided tutorial on component-driven development at{' '}
-          <a href="https://storybook.js.org/tutorials/" target="_blank" rel="noopener noreferrer">
-            Storybook tutorials
-          </a>
-          . Read more in the{' '}
-          <a href="https://storybook.js.org/docs" target="_blank" rel="noopener noreferrer">
-            docs
-          </a>
-          .
-        </p>
-        <div className="tip-wrapper">
-          <span className="tip">Tip</span> Adjust the width of the canvas with the{' '}
-          <svg width="10" height="10" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg">
-            <g fill="none" fillRule="evenodd">
-              <path
-                d="M1.5 5.2h4.8c.3 0 .5.2.5.4v5.1c-.1.2-.3.3-.4.3H1.4a.5.5 0 01-.5-.4V5.7c0-.3.2-.5.5-.5zm0-2.1h6.9c.3 0 .5.2.5.4v7a.5.5 0 01-1 0V4H1.5a.5.5 0 010-1zm0-2.1h9c.3 0 .5.2.5.4v9.1a.5.5 0 01-1 0V2H1.5a.5.5 0 010-1zm4.3 5.2H2V10h3.8V6.2z"
-                id="a"
-                fill="#999"
-              />
-            </g>
-          </svg>
-          Viewports addon in the toolbar
-        </div>
-      </section>
-    </article>
-  );
-};
+			<section>
+				<h2>Pages in Storybook</h2>
+				<p>
+					We recommend building UIs with a{' '}
+					<a
+						href='https://componentdriven.org'
+						target='_blank'
+						rel='noopener noreferrer'
+					>
+						<strong>component-driven</strong>
+					</a>{' '}
+					process starting with atomic components and ending with pages.
+				</p>
+				<p>
+					Render pages with mock data. This makes it easy to build and review
+					page states without needing to navigate to them in your app. Here are
+					some handy patterns for managing page data in Storybook:
+				</p>
+				<ul>
+					<li>
+						Use a higher-level connected component. Storybook helps you compose
+						such data from the
+						{'args'} of child component stories
+					</li>
+					<li>
+						Assemble data in the page component from your services. You can mock
+						these services out using Storybook.
+					</li>
+				</ul>
+				<p>
+					Get a guided tutorial on component-driven development at{' '}
+					<a
+						href='https://storybook.js.org/tutorials/'
+						target='_blank'
+						rel='noopener noreferrer'
+					>
+						Storybook tutorials
+					</a>
+					. Read more in the{' '}
+					<a
+						href='https://storybook.js.org/docs'
+						target='_blank'
+						rel='noopener noreferrer'
+					>
+						docs
+					</a>
+					.
+				</p>
+				<div className='tip-wrapper'>
+					<span className='tip'>Tip</span> Adjust the width of the canvas with
+					the{' '}
+					<svg
+						width='10'
+						height='10'
+						viewBox='0 0 12 12'
+						xmlns='http://www.w3.org/2000/svg'
+					>
+						<g fill='none' fillRule='evenodd'>
+							<path
+								d='M1.5 5.2h4.8c.3 0 .5.2.5.4v5.1c-.1.2-.3.3-.4.3H1.4a.5.5 0 01-.5-.4V5.7c0-.3.2-.5.5-.5zm0-2.1h6.9c.3 0 .5.2.5.4v7a.5.5 0 01-1 0V4H1.5a.5.5 0 010-1zm0-2.1h9c.3 0 .5.2.5.4v9.1a.5.5 0 01-1 0V2H1.5a.5.5 0 010-1zm4.3 5.2H2V10h3.8V6.2z'
+								id='a'
+								fill='#999'
+							/>
+						</g>
+					</svg>
+					Viewports addon in the toolbar
+				</div>
+			</section>
+		</article>
+	)
+}

--- a/src/stories/button.css
+++ b/src/stories/button.css
@@ -1,30 +1,30 @@
 .storybook-button {
-  font-family: 'Nunito Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
-  font-weight: 700;
-  border: 0;
-  border-radius: 3em;
-  cursor: pointer;
-  display: inline-block;
-  line-height: 1;
+	font-family: 'Nunito Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+	font-weight: 700;
+	border: 0;
+	border-radius: 3em;
+	cursor: pointer;
+	display: inline-block;
+	line-height: 1;
 }
 .storybook-button--primary {
-  color: white;
-  background-color: #1ea7fd;
+	color: white;
+	background-color: #1ea7fd;
 }
 .storybook-button--secondary {
-  color: #333;
-  background-color: transparent;
-  box-shadow: rgba(0, 0, 0, 0.15) 0px 0px 0px 1px inset;
+	color: #333;
+	background-color: transparent;
+	box-shadow: rgba(0, 0, 0, 0.15) 0px 0px 0px 1px inset;
 }
 .storybook-button--small {
-  font-size: 12px;
-  padding: 10px 16px;
+	font-size: 12px;
+	padding: 10px 16px;
 }
 .storybook-button--medium {
-  font-size: 14px;
-  padding: 11px 20px;
+	font-size: 14px;
+	padding: 11px 20px;
 }
 .storybook-button--large {
-  font-size: 16px;
-  padding: 12px 24px;
+	font-size: 16px;
+	padding: 12px 24px;
 }

--- a/src/stories/header.css
+++ b/src/stories/header.css
@@ -1,32 +1,32 @@
 .wrapper {
-  font-family: 'Nunito Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
-  border-bottom: 1px solid rgba(0, 0, 0, 0.1);
-  padding: 15px 20px;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
+	font-family: 'Nunito Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+	border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+	padding: 15px 20px;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
 }
 
 svg {
-  display: inline-block;
-  vertical-align: top;
+	display: inline-block;
+	vertical-align: top;
 }
 
 h1 {
-  font-weight: 900;
-  font-size: 20px;
-  line-height: 1;
-  margin: 6px 0 6px 10px;
-  display: inline-block;
-  vertical-align: top;
+	font-weight: 900;
+	font-size: 20px;
+	line-height: 1;
+	margin: 6px 0 6px 10px;
+	display: inline-block;
+	vertical-align: top;
 }
 
 button + button {
-  margin-left: 10px;
+	margin-left: 10px;
 }
 
 .welcome {
-  color: #333;
-  font-size: 14px;
-  margin-right: 10px;
+	color: #333;
+	font-size: 14px;
+	margin-right: 10px;
 }

--- a/src/stories/page.css
+++ b/src/stories/page.css
@@ -1,69 +1,69 @@
 section {
-  font-family: 'Nunito Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
-  font-size: 14px;
-  line-height: 24px;
-  padding: 48px 20px;
-  margin: 0 auto;
-  max-width: 600px;
-  color: #333;
+	font-family: 'Nunito Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+	font-size: 14px;
+	line-height: 24px;
+	padding: 48px 20px;
+	margin: 0 auto;
+	max-width: 600px;
+	color: #333;
 }
 
 section h2 {
-  font-weight: 900;
-  font-size: 32px;
-  line-height: 1;
-  margin: 0 0 4px;
-  display: inline-block;
-  vertical-align: top;
+	font-weight: 900;
+	font-size: 32px;
+	line-height: 1;
+	margin: 0 0 4px;
+	display: inline-block;
+	vertical-align: top;
 }
 
 section p {
-  margin: 1em 0;
+	margin: 1em 0;
 }
 
 section a {
-  text-decoration: none;
-  color: #1ea7fd;
+	text-decoration: none;
+	color: #1ea7fd;
 }
 
 section ul {
-  padding-left: 30px;
-  margin: 1em 0;
+	padding-left: 30px;
+	margin: 1em 0;
 }
 
 section li {
-  margin-bottom: 8px;
+	margin-bottom: 8px;
 }
 
 section .tip {
-  display: inline-block;
-  border-radius: 1em;
-  font-size: 11px;
-  line-height: 12px;
-  font-weight: 700;
-  background: #e7fdd8;
-  color: #66bf3c;
-  padding: 4px 12px;
-  margin-right: 10px;
-  vertical-align: top;
+	display: inline-block;
+	border-radius: 1em;
+	font-size: 11px;
+	line-height: 12px;
+	font-weight: 700;
+	background: #e7fdd8;
+	color: #66bf3c;
+	padding: 4px 12px;
+	margin-right: 10px;
+	vertical-align: top;
 }
 
 section .tip-wrapper {
-  font-size: 13px;
-  line-height: 20px;
-  margin-top: 40px;
-  margin-bottom: 40px;
+	font-size: 13px;
+	line-height: 20px;
+	margin-top: 40px;
+	margin-bottom: 40px;
 }
 
 section .tip-wrapper svg {
-  display: inline-block;
-  height: 12px;
-  width: 12px;
-  margin-right: 4px;
-  vertical-align: top;
-  margin-top: 3px;
+	display: inline-block;
+	height: 12px;
+	width: 12px;
+	margin-right: 4px;
+	vertical-align: top;
+	margin-top: 3px;
 }
 
 section .tip-wrapper svg path {
-  fill: #1ea7fd;
+	fill: #1ea7fd;
 }

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,19 +1,19 @@
-import { createTheme } from '@mui/material/styles';
-import { red } from '@mui/material/colors';
+import { createTheme } from '@mui/material/styles'
+import { red } from '@mui/material/colors'
 
 // Create a theme instance.
 const theme = createTheme({
-  palette: {
-    primary: {
-      main: '#556cd6',
-    },
-    secondary: {
-      main: '#19857b',
-    },
-    error: {
-      main: red.A400,
-    },
-  },
-});
+	palette: {
+		primary: {
+			main: '#556cd6',
+		},
+		secondary: {
+			main: '#19857b',
+		},
+		error: {
+			main: red.A400,
+		},
+	},
+})
 
-export default theme;
+export default theme

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,21 +1,21 @@
 {
-  "compilerOptions": {
-    "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
-    "allowJs": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "forceConsistentCasingInFileNames": true,
-    "noEmit": true,
-    "esModuleInterop": true,
-    "module": "esnext",
-    "moduleResolution": "node",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "jsx": "preserve",
-    "jsxImportSource": "@emotion/react",
-    "incremental": true
-  },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+	"compilerOptions": {
+		"target": "es5",
+		"lib": ["dom", "dom.iterable", "esnext"],
+		"allowJs": true,
+		"skipLibCheck": true,
+		"strict": true,
+		"forceConsistentCasingInFileNames": true,
+		"noEmit": true,
+		"esModuleInterop": true,
+		"module": "esnext",
+		"moduleResolution": "node",
+		"resolveJsonModule": true,
+		"isolatedModules": true,
+		"jsx": "preserve",
+		"jsxImportSource": "@emotion/react",
+		"incremental": true
+	},
+	"include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+	"exclude": ["node_modules"]
 }


### PR DESCRIPTION
This PR:

1. Executes `yarn prettier` to format the existing code. There were a number of formatting changes that Prettier proposed.
2. Adds a GitHub Actions workflow to run `yarn lint` and Prettier (via a helper script) on PR branches and pushes to main.

The main files of interest in this PR are under the `.github/` directory.

A couple of decisions we should make before merging this change:

- [ ] Are we happy with the default Prettier formatting rules, or would we like to explore a custom or alternate ruleset? This will be annoying to change in the future as a new ruleset could result in a large number of formatting changes that each branch will need to synchronise on.
- [ ] Are we happy with the ESLint configuration?