### PR TITLE
ci(codeql): update workflow to run on PRs to `main`

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,9 @@ name: 'CodeQL'
 
 on:
   push:
-    branches: [dev, main]
+    branches: [main]
   pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [dev]
+    branches: [main]
   schedule:
     - cron: '42 4 * * 3'
 


### PR DESCRIPTION
This workflow previously ran on PRs targeting the dev branch which
no longer exists. Since CodeQL is marked as a required check, all PRs
to `main` were being blocked indefinitely.