### PR TITLE
ci(package.json): move commit lint pckgs to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,15 +23,12 @@
 	},
 	"dependencies": {
 		"@babel/core": "^7.0.0",
-		"@commitlint/cli": "^16.2.4",
-		"@commitlint/config-conventional": "^16.2.4",
 		"@emotion/cache": "^11.7.1",
 		"@emotion/react": "^11.9.0",
 		"@emotion/server": "^11.4.0",
 		"@emotion/styled": "^11.8.1",
 		"@mui/icons-material": "latest",
 		"@mui/material": "latest",
-		"commitizen": "^4.2.4",
 		"next": "12.1.5",
 		"react": "latest",
 		"react-dom": "latest"
@@ -59,7 +56,10 @@
 		"lint-staged": "^12.4.1",
 		"prettier": "^2.6.2",
 		"storybook-addon-next-router": "^3.1.1",
-		"typescript": "latest"
+		"typescript": "latest",
+		"commitizen": "^4.2.4",
+		"@commitlint/cli": "^16.2.4",
+		"@commitlint/config-conventional": "^16.2.4"
 	},
 	"config": {
 		"commitizen": {


### PR DESCRIPTION
Move three commit-lint related packages to the dev dependencies section (from the prod dependencies
section) in package.json.

BREAKING CHANGE: Unlikely to break anything but technically moving around production dependencies
should be classified as a "breaking" change.