### PR TITLE
docs(readme): add three badges to top of the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # OMSHub
 
+[![license](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
+![contributors count](https://img.shields.io/github/contributors/omshub/website)
+![pull requests closed](https://img.shields.io/github/issues-pr-closed/omshub/website)
+
 A website for Online Master's of Science (OMS) course reviews at Georgia Tech.
 
 ## Resources


### PR DESCRIPTION
Demo screenshot:
![pr-82-demo](https://user-images.githubusercontent.com/20162718/168996374-b3cd7d39-f436-47e8-b0e2-2c63769e6897.png)

Added three badges to the top of the README with useful information.

- License: display the type of license used on this project with a link
  to the license text.
- Contributors: display the total number of contributors on this
  repository.
- Pull requests: display the total number of pull requests that have
  been closed on this repository.

The goal of the license badge is to avoid the need to add an entire
"license" section to the README. The goal of the other two badges is to
(hopefully) increase engagement by encouraging community members to
contribute to our project so they can watch the number of contributors
and PRs increase in real-time.

re #64