### PR TITLE
fix(index): make index page table responsive

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -87,7 +87,7 @@ const Home: NextPage = () => {
 				</Typography>
 
 				<>
-					<Grid container spacing={3}>
+					<Grid container sx={{ marginLeft: 0, width: `100%` }} spacing={3}>
 						<DataGrid
 							autoHeight
 							disableColumnSelector


### PR DESCRIPTION
Originally, the site looks like this on Mobile or Narrow view:
<img width="448" alt="Screen Shot 2022-06-17 at 4 42 17 PM" src="https://user-images.githubusercontent.com/45903727/174413025-e887d8b6-9d21-45fd-9a57-d8e22088217c.png">

Fixed by modifying styles a small amount
<img width="445" alt="Screen Shot 2022-06-17 at 4 34 45 PM" src="https://user-images.githubusercontent.com/45903727/174413046-07e5c560-b0dd-41e4-921d-76b62db168ad.png">

