### PR TITLE
fix: color "course average" detail cards correctly

### DIFF
--- a/pages/course/[courseid].tsx
+++ b/pages/course/[courseid].tsx
@@ -13,9 +13,9 @@ import ToggleButton from '@mui/material/ToggleButton'
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup'
 import Typography from '@mui/material/Typography'
 import {
-	mapColorPalette,
-	mapColorPaletteInverted,
 	mapPayloadToArray,
+	mapRatingToColor,
+	mapRatingToColorInverted,
 	mapSemesterTermToEmoji,
 	mapSemesterTermToName,
 	roundNumber,
@@ -168,7 +168,15 @@ const CourseId: NextPage<CoursePageProps> = ({
 								</Card>
 							</Grid>
 							<Grid item xs={12} lg={4}>
-								<Card variant='outlined' sx={{ padding: '5 30' }}>
+								<Card
+									variant='outlined'
+									sx={{
+										padding: '5 30',
+										borderColor: mapRatingToColorInverted(
+											Number(courseData?.avgDifficulty)
+										),
+									}}
+								>
 									<CardContent>
 										<Typography
 											sx={{ fontSize: 14 }}
@@ -180,14 +188,9 @@ const CourseId: NextPage<CoursePageProps> = ({
 										<Typography
 											variant='h5'
 											sx={{
-												color:
-													mapColorPaletteInverted[
-														Number(courseData?.avgDifficulty)
-													],
-												border:
-													mapColorPaletteInverted[
-														Number(courseData?.avgDifficulty)
-													],
+												color: mapRatingToColorInverted(
+													Number(courseData?.avgDifficulty)
+												),
 											}}
 										>
 											{roundNumber(Number(courseData?.avgDifficulty), 1) +
@@ -197,7 +200,16 @@ const CourseId: NextPage<CoursePageProps> = ({
 								</Card>
 							</Grid>
 							<Grid item xs={12} lg={4}>
-								<Card variant='outlined' sx={{ margin: '10', padding: '5 30' }}>
+								<Card
+									variant='outlined'
+									sx={{
+										margin: '10',
+										padding: '5 30',
+										borderColor: mapRatingToColor(
+											Number(courseData.avgOverall)
+										),
+									}}
+								>
 									<CardContent>
 										<Typography
 											sx={{ fontSize: 14 }}
@@ -209,8 +221,7 @@ const CourseId: NextPage<CoursePageProps> = ({
 										<Typography
 											variant='h5'
 											sx={{
-												color: mapColorPalette[Number(courseData.avgOverall)],
-												border: mapColorPalette[Number(courseData.avgOverall)],
+												color: mapRatingToColor(Number(courseData.avgOverall)),
 											}}
 										>
 											{roundNumber(Number(courseData.avgOverall), 1) + ' /5'}

--- a/src/components/ReviewCard.tsx
+++ b/src/components/ReviewCard.tsx
@@ -8,10 +8,10 @@ import { grey } from '@mui/material/colors'
 import Grid from '@mui/material/Grid'
 import Typography from '@mui/material/Typography'
 import {
-	mapColorPalette,
-	mapColorPaletteInverted,
 	mapDifficulty,
 	mapOverall,
+	mapRatingToColor,
+	mapRatingToColorInverted,
 	mapSemesterIdToName,
 } from '@src/utilities'
 import ReactMarkdown from 'react-markdown'
@@ -80,8 +80,8 @@ const ReviewCard = ({
 							<Chip
 								label={`Difficulty: ${mapDifficulty[difficulty]}`}
 								sx={{
-									color: mapColorPaletteInverted[difficulty],
-									borderColor: mapColorPaletteInverted[difficulty],
+									color: mapRatingToColorInverted(difficulty),
+									borderColor: mapRatingToColorInverted(difficulty),
 								}}
 								variant='outlined'
 							></Chip>
@@ -90,8 +90,8 @@ const ReviewCard = ({
 							<Chip
 								label={`Overall: ${mapOverall[overall]}`}
 								sx={{
-									color: mapColorPalette[overall],
-									borderColor: mapColorPalette[overall],
+									color: mapRatingToColor(overall),
+									borderColor: mapRatingToColor(overall),
 								}}
 								variant='outlined'
 								color='primary'

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -4,7 +4,7 @@ import {
 	canopyLime,
 	newHorizon,
 	olympicTeal,
-	RATCap
+	RATCap,
 } from '@src/colorPalette'
 
 type TMapFields = {
@@ -82,14 +82,15 @@ export const mapRatingToColor = (rating: Number) => {
 		5: canopyLime,
 	}
 
-	return mapColorPalette[Math.round(rating.valueOf())];
+	return mapColorPalette[Math.round(rating.valueOf())]
 }
 
 /**
  * Same as mapRatingToColor, except low values are "good" and higher values "bad"
  * @see mapRatingToColor
  */
-export const mapRatingToColorInverted = (rating: Number) => mapRatingToColor(-rating + 6);
+export const mapRatingToColorInverted = (rating: Number) =>
+	mapRatingToColor(-rating + 6)
 
 export const mapPayloadToArray = (
 	map: TObject | undefined,

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -4,7 +4,7 @@ import {
 	canopyLime,
 	newHorizon,
 	olympicTeal,
-	RATCap,
+	RATCap
 } from '@src/colorPalette'
 
 type TMapFields = {
@@ -33,22 +33,6 @@ export const mapStaffSupport: TMapFields = {
 	3: 'Neutral',
 	4: 'Supportive',
 	5: 'Strong Support',
-}
-
-export const mapColorPalette: TMapFields = {
-	1: newHorizon,
-	2: RATCap,
-	3: boldBlue,
-	4: olympicTeal,
-	5: canopyLime,
-}
-
-export const mapColorPaletteInverted: TMapFields = {
-	1: canopyLime,
-	2: olympicTeal,
-	3: boldBlue,
-	4: RATCap,
-	5: newHorizon,
 }
 
 export const mapSemesterTermToName: TMapFields = {
@@ -85,6 +69,27 @@ type TSortKey =
 	| 'specializationId'
 	| 'userId'
 type TSortDirection = 'ASC' | 'DESC'
+
+/**
+ * Returns a hex color string from a 1-5 rating, with 1 being "bad" and 5 being "good"
+ */
+export const mapRatingToColor = (rating: Number) => {
+	const mapColorPalette: TMapFields = {
+		1: newHorizon,
+		2: RATCap,
+		3: boldBlue,
+		4: olympicTeal,
+		5: canopyLime,
+	}
+
+	return mapColorPalette[Math.round(rating.valueOf())];
+}
+
+/**
+ * Same as mapRatingToColor, except low values are "good" and higher values "bad"
+ * @see mapRatingToColor
+ */
+export const mapRatingToColorInverted = (rating: Number) => mapRatingToColor(-rating + 6);
 
 export const mapPayloadToArray = (
 	map: TObject | undefined,


### PR DESCRIPTION
The previous mechanism for coloring these used a non-rounded average value as
a key for an int->color map lookup. This change replaces map lookups inside
components with function calls that handle the rounding logic.

fix #134