### PR TITLE
feat: add a visible "Legacy" label to legacy reviews

### DIFF
--- a/src/components/ReviewCard.tsx
+++ b/src/components/ReviewCard.tsx
@@ -1,5 +1,6 @@
 import { Review } from '@globals/types'
 import { getCourseDataStatic } from '@globals/utilities'
+import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline'
 import Box from '@mui/material/Box'
 import Card from '@mui/material/Card'
 import CardContent from '@mui/material/CardContent'
@@ -25,6 +26,7 @@ const ReviewCard = ({
 	created,
 	year,
 	courseId,
+	isLegacy,
 }: Review) => {
 	const timestamp = new Date(created).toLocaleDateString()
 	const { name: courseName } = getCourseDataStatic(courseId)
@@ -53,7 +55,7 @@ const ReviewCard = ({
 						Taken {mapSemesterIdToName[semesterId]} {year}
 					</Typography>
 					<Typography color='text.secondary'>
-						Reviewed on {timestamp}
+						{`Reviewed on ${timestamp}${isLegacy && ' @ omscentral.com'}`}
 					</Typography>
 				</Box>
 				<Box
@@ -70,11 +72,19 @@ const ReviewCard = ({
 						justifyContent='flex-start'
 						alignItems='flex-start'
 					>
+						{isLegacy && (
+							<Grid item>
+								<Chip
+									title='This review was originally collected on https://omscentral.com'
+									icon={<ErrorOutlineIcon />}
+									color='warning'
+									label='Legacy'
+									variant='outlined'
+								/>
+							</Grid>
+						)}
 						<Grid item>
-							<Chip
-								label={`Workload: ${workload} hr/wk`}
-								variant='outlined'
-							></Chip>
+							<Chip label={`Workload: ${workload} hr/wk`} variant='outlined' />
 						</Grid>
 						<Grid item>
 							<Chip
@@ -84,7 +94,7 @@ const ReviewCard = ({
 									borderColor: mapRatingToColorInverted(difficulty),
 								}}
 								variant='outlined'
-							></Chip>
+							/>
 						</Grid>
 						<Grid item>
 							<Chip
@@ -94,8 +104,7 @@ const ReviewCard = ({
 									borderColor: mapRatingToColor(overall),
 								}}
 								variant='outlined'
-								color='primary'
-							></Chip>
+							/>
 						</Grid>
 					</Grid>
 				</Box>


### PR DESCRIPTION
This change is to add a visual distinction between legacy/omscentral.com reviews, and new OMSHub
reviews

fix #152