### PR TITLE
fix:  add logic to account for registration periods when rendering current registration on first load

### DIFF
--- a/app/schedule/_components/ScheduleContent.tsx
+++ b/app/schedule/_components/ScheduleContent.tsx
@@ -176,9 +176,26 @@ function getCurrentSemester(): { year: number; semester: 'sp' | 'sm' | 'fa' } {
   }
 }
 
+// Get current registration period based on month
+function getCurrentRegistrationSemester(): { year: number; semester: 'sp' | 'sm' | 'fa' } {
+  const now = new Date();
+  const month = now.getMonth() + 1; // 1-12
+  let year = now.getFullYear();
+
+  if (month >= 4 && month < 6) {
+    return { year, semester: 'sm' };           // Summer registration: Apr-May
+  } else if (month >= 6 && month < 11) {
+    return { year, semester: 'fa' };           // Fall registration: Jun-Aug
+  } else if (month >= 11) {
+    return { year: year + 1, semester: 'sp' }; // Spring registration: Nov-Jan
+  } else {
+    return { year, semester: 'sp' };
+  }
+}
+
 // Past semesters from current back to 2014, most recent first
 function getPastSemesters(): { value: string; label: string }[] {
-  const { year: currentYear, semester: currentSem } = getCurrentSemester();
+  const { year: currentYear, semester: currentSem } = getCurrentRegistrationSemester();
   const semesters: { value: string; label: string }[] = [];
   const semesterOrder: ('sp' | 'sm' | 'fa')[] = ['sp', 'sm', 'fa'];
   const startYear = 2014; // OMSCS program started
@@ -206,7 +223,7 @@ function getPastSemesters(): { value: string; label: string }[] {
 
 // Returns the next N future term codes after the current semester
 function getFutureCandidates(n: number): string[] {
-  const { year: currentYear, semester: currentSem } = getCurrentSemester();
+  const { year: currentYear, semester: currentSem } = getCurrentRegistrationSemester();
   const semesterOrder: ('sp' | 'sm' | 'fa')[] = ['sp', 'sm', 'fa'];
   const candidates: string[] = [];
 

--- a/app/schedule/_components/ScheduleContent.tsx
+++ b/app/schedule/_components/ScheduleContent.tsx
@@ -180,7 +180,7 @@ function getCurrentSemester(): { year: number; semester: 'sp' | 'sm' | 'fa' } {
 function getCurrentRegistrationSemester(): { year: number; semester: 'sp' | 'sm' | 'fa' } {
   const now = new Date();
   const month = now.getMonth() + 1; // 1-12
-  let year = now.getFullYear();
+  const year = now.getFullYear();
 
   if (month >= 4 && month < 6) {
     return { year, semester: 'sm' };           // Summer registration: Apr-May


### PR DESCRIPTION
@tran-christian not sure if this conflicts at all with your in-progress branch, but at least in terms of proof of concept, this will fix first-load artifacts in the schedule page. It's currently loading based on current semester for setting "active," but this is somewhat incorrect. The registration periods are generally offset, with registration for semester X generally occurring around mid-late way through semester X-1; more concretely:

| Current Semester | Next Semester | Next Semester Registration (occurs during Current Semester) |
|:--|:--|:--|
| Spring | Summer | April-May |
| Summer | Fall | Jun-Aug |
| Fall | Spring | Nov-Jan |
 
Thus, by the time April, June, and Nov roll around, OSCAR should be populating the next semester registration data by that point, and schedule should be initializing accordingly, rather than teeing up "stale" registration info going into Phase 1 registration. This came up as a bug report on Slack, where the initial load of page was loading (effectively) Spring 2026 registration data while Summer 2026 registration was already ongoing as of mid-April, when reported.