### PR TITLE
fix(schedule): cancel stale fetches when activeSemester changes

### DIFF
--- a/app/schedule/_components/ScheduleContent.tsx
+++ b/app/schedule/_components/ScheduleContent.tsx
@@ -351,9 +351,17 @@ export default function ScheduleContent() {
   }, [pastSemesters]);
 
   useEffect(() => {
+    // Cancellation flag: the probe effect can change activeSemester mid-fetch,
+    // triggering a second run of this effect. Without this guard, a slower
+    // earlier fetch can land after the newer one and overwrite fresh data with
+    // the previous semester's rows — producing the "Summer 2026 shows Spring 2026
+    // enrollment" hydration artifact reported on Slack.
+    let cancelled = false;
+
     async function fetchData() {
       setLoading(true);
       setError(null);
+      setSections([]);
 
       try {
         // Fetch course metadata, availability, specializations, and programs in parallel
@@ -363,6 +371,8 @@ export default function ScheduleContent() {
           fetch(`${DATA_REPO_BASE}/static/specializations.json`),
           fetch(`${DATA_REPO_BASE}/static/programs.json`),
         ]);
+
+        if (cancelled) return;
 
         if (!metadataResponse.ok) {
           throw new Error('Failed to fetch course metadata');
@@ -382,14 +392,16 @@ export default function ScheduleContent() {
         const metadata: CourseMetadataMap = await metadataResponse.json();
         const availability: RawAvailabilityData = await availabilityResponse.json();
 
+        if (cancelled) return;
+
         // Parse specializations and programs (non-critical, so don't fail on error)
         if (specializationsResponse.ok) {
           const specData: SpecializationMap = await specializationsResponse.json();
-          setSpecializations(specData);
+          if (!cancelled) setSpecializations(specData);
         }
         if (programsResponse.ok) {
           const progData: ProgramMap = await programsResponse.json();
-          setPrograms(progData);
+          if (!cancelled) setPrograms(progData);
         }
 
         // Combine data
@@ -439,17 +451,24 @@ export default function ScheduleContent() {
         // Sort by courseId
         combinedSections.sort((a, b) => a.courseId.localeCompare(b.courseId));
 
+        if (cancelled) return;
+
         setSections(combinedSections);
         setLastUpdated(availability.lastUpdated ? new Date(availability.lastUpdated).toLocaleString() : new Date().toLocaleTimeString());
       } catch (err) {
+        if (cancelled) return;
         console.error('Error fetching availability data:', err);
         setError(err instanceof Error ? err.message : 'Failed to load data');
       } finally {
-        setLoading(false);
+        if (!cancelled) setLoading(false);
       }
     }
 
     fetchData();
+
+    return () => {
+      cancelled = true;
+    };
   }, [activeSemester]);
 
   // Build specialization options for dropdown (flat list with program prefix)


### PR DESCRIPTION
## Summary
- Fixes the Slack-reported bug where Summer 2026 displayed Spring 2026 enrollment data (GIOS 1184/1300, plus AOS and SIR rows that don't exist in the Summer term).
- Root cause is a race condition introduced alongside #813: the future-semester probe effect fires concurrently with the first data-fetch effect, and when the probe flips `activeSemester` to Summer 2026, two fetches are in flight simultaneously. If the Spring 2026 response lands after the Summer 2026 response, its `setSections` overwrites the fresh data — so the dropdown heading reads "Summer 2026" while the table shows Spring 2026 rows.
- Guards every state setter in the fetch effect behind a `cancelled` flag tracked in the cleanup, and clears `sections` synchronously at the start of each run so the previous semester's rows don't flash under the new heading during loading.

Note: #828 tackles the same bug with a different approach (treating "current" as the registration window rather than the running term). That heuristic masks the race under common timing but doesn't eliminate it — e.g. a slow Spring 2026 fetch can still land after a Fall 2026 probe flips `activeSemester`. The `cancelled` flag here addresses the underlying React pattern regardless of which heuristic picks the initial semester, so the two PRs are complementary.

## Test plan
- [x] Load `/schedule` with dev server — heading reads "Summer 2026 Courses", GIOS 9/750, 54 sections, AOS absent (matches `data/202605.json` from omshub/data).
- [x] Toggle dropdown to Spring 2026 — GIOS 1184/1300, AOS 361/475, 69 sections (matches `data/202602.json`).
- [x] Spot-check Fall 2025 (GIOS 1032/1100), Summer 2025 (292/750), Fall 2021 (735/850) against the data repo — all match.
- [x] Race-condition stress test: patch `window.fetch` to delay `202602.json` responses by 3 s, click Spring 2026, immediately click Summer 2026, wait 5 s. Without the fix the late Spring response overwrites Summer rows; with the fix, Summer 2026 data survives (GIOS 9/750, AOS absent).
- [ ] Follow-up: add an automated regression test that checks the rendered schedule against live data-repo values and exercises the cancellation pattern. Tracked for a separate PR so this fix can ship immediately.