### PR TITLE
fix(auth): stamp session cookies onto redirect response after OAuth exchange

### DIFF
--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -5,19 +5,33 @@ import { NextResponse } from 'next/server';
 export async function GET(request: Request) {
   const { searchParams, origin } = new URL(request.url);
   const code = searchParams.get('code');
-  const next = searchParams.get('next') ?? '/';
 
-  // GoTrue redirects here with error params when OAuth fails server-side
+  // Reject non-relative paths (including //host bypasses) to prevent open-redirect.
+  const rawNext = searchParams.get('next') ?? '/';
+  const next = rawNext.startsWith('/') && !rawNext.startsWith('//') ? rawNext : '/';
+
+  // GoTrue redirects here with error params when OAuth fails server-side.
   const oauthError = searchParams.get('error');
-  const oauthErrorDescription = searchParams.get('error_description');
   if (oauthError) {
-    const params = new URLSearchParams({ error: oauthError, ...(oauthErrorDescription ? { error_description: oauthErrorDescription } : {}) });
+    const params = new URLSearchParams({ error: oauthError });
+    const desc = searchParams.get('error_description');
+    if (desc) params.set('error_description', desc);
     return NextResponse.redirect(`${origin}/?${params}`);
   }
 
+  // cookieStore is needed for both the success and error paths below.
   const cookieStore = await cookies();
 
   if (code) {
+    // Buffer cookies from setAll() so we can explicitly stamp them onto the
+    // redirect response. Next.js does not propagate cookies() mutations into
+    // NextResponse.redirect() automatically — omitting this loses the session.
+    const pendingCookies: Array<{
+      name: string;
+      value: string;
+      options: Record<string, unknown>;
+    }> = [];
+
     const supabase = createServerClient(
       process.env.NEXT_PUBLIC_SUPABASE_URL!,
       process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
@@ -27,13 +41,7 @@ export async function GET(request: Request) {
             return cookieStore.getAll();
           },
           setAll(cookiesToSet) {
-            try {
-              cookiesToSet.forEach(({ name, value, options }) =>
-                cookieStore.set(name, value, options)
-              );
-            } catch {
-              // Handle cookie errors
-            }
+            pendingCookies.push(...cookiesToSet);
           },
         },
       }
@@ -42,17 +50,27 @@ export async function GET(request: Request) {
     const { error } = await supabase.auth.exchangeCodeForSession(code);
 
     if (!error) {
-      return NextResponse.redirect(`${origin}${next}`);
+      const response = NextResponse.redirect(`${origin}${next}`);
+      for (const { name, value, options } of pendingCookies) {
+        response.cookies.set(
+          name,
+          value,
+          options as Parameters<typeof response.cookies.set>[2]
+        );
+      }
+      return response;
     }
+
+    console.error('[auth/callback] exchangeCodeForSession failed:', error.message);
   }
 
-  // Return to home with error. Clear only the PKCE code_verifier cookie so the
-  // next sign-in attempt starts with a fresh verifier. We avoid wiping the
-  // entire session (all sb-* cookies) to prevent logging out a user who has a
-  // valid session but hit a transient Supabase error during the exchange.
+  // Clear the PKCE verifier so the next attempt starts fresh.
+  // Avoid clearing all sb-* cookies — a valid parallel session should survive.
   const errorResponse = NextResponse.redirect(`${origin}/?error=auth_callback_error`);
-  cookieStore.getAll()
-    .filter(c => c.name.endsWith('-auth-token-code-verifier'))
-    .forEach(c => errorResponse.cookies.set(c.name, '', { maxAge: 0, path: '/' }));
+  for (const c of cookieStore.getAll()) {
+    if (c.name.endsWith('-auth-token-code-verifier')) {
+      errorResponse.cookies.set(c.name, '', { maxAge: 0, path: '/' });
+    }
+  }
   return errorResponse;
 }

--- a/src/components/LoginDrawer.tsx
+++ b/src/components/LoginDrawer.tsx
@@ -157,7 +157,9 @@ export default function LoginDrawer({ opened, onClose }: LoginDrawerProps) {
     setLoadingProvider(provider);
 
     try {
-      authContext.signInWithProvider(provider);
+      await authContext.signInWithProvider(provider);
+      // On success, signInWithOAuth navigates the browser away immediately,
+      // so handleClose() is only reached on error paths.
       handleClose();
     } finally {
       // Reset after a delay to allow popup to open


### PR DESCRIPTION
## Summary

- **Root cause**: Next.js does not propagate `cookies()` mutations into `NextResponse.redirect()` — session tokens were never delivered to the browser despite Supabase returning a valid token, so OAuth and magic-link logins silently failed
- **Fix**: Buffer cookies in a `pendingCookies[]` array during `setAll()`, then explicitly stamp each one onto the `NextResponse.redirect()` response object before returning
- **Security**: Guard the `next` param against `//host` open-redirect bypass; use plain `origin` (from `new URL(request.url)`) for all redirects — avoids cross-origin cookie mismatches on preview deployments that would occur with `NEXT_PUBLIC_SITE_URL`, and avoids the open-redirect risk of trusting `x-forwarded-host`
- **LoginDrawer**: `await` the `signInWithProvider` call so errors surface via the existing `notifyError` toast instead of being swallowed

## Test plan

- [ ] Click "Continue with Google" → completes OAuth flow → lands on homepage signed in
- [ ] Click "Continue with GitHub" → completes OAuth flow → lands on homepage signed in
- [ ] Send magic link → click link in email → lands on homepage signed in
- [ ] Send magic link → enter OTP code → signs in without page navigation
- [ ] OAuth failure (revoke app access mid-flow) → redirected to `/?error=auth_callback_error`
- [ ] Malformed `next` param (`//evil.com`) → redirected to `/` not external host
- [ ] Preview deployment OAuth → session persists (cookies written to same origin as redirect)