### PR TITLE
chore(auth): route callback diagnostics to Vercel logs, drop auth_debug cookie

### DIFF
--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -28,8 +28,8 @@ import { NextResponse } from 'next/server';
 
 /**
  * Build the failure redirect for the home page. Encodes a machine-readable
- * `reason` so the next sign-in attempt is conclusive without needing logs —
- * `removeConsole: true` strips server-side console.error in prod.
+ * `reason` so a sign-in attempt is conclusive from the URL alone, without
+ * needing server logs.
  */
 function failureRedirect(
   origin: string,
@@ -37,8 +37,7 @@ function failureRedirect(
     | 'no_code'
     | 'exchange_failed'
     | 'no_session'
-    | 'no_pending_cookies'
-    | 'oauth_error',
+    | 'no_pending_cookies',
   extras?: Record<string, string>
 ) {
   const params = new URLSearchParams({ error: 'auth_callback_error', reason });
@@ -98,31 +97,30 @@ export async function GET(request: Request) {
 
   const { data, error } = await supabase.auth.exchangeCodeForSession(code);
 
-  // Full diagnostic dump, only when DEBUG_AUTH=1. `removeConsole` is
-  // wired in next.config.js to preserve console.* when that flag is set,
-  // so these lines survive `pnpm build && pnpm start` for local repro.
-  if (process.env.DEBUG_AUTH === '1') {
-    console.log('[auth/callback] exchange result', {
-      error: error?.message,
-      errorStatus: (error as { status?: number } | null)?.status,
-      hasSession: !!data?.session,
-      hasUser: !!data?.user,
-      userId: data?.user?.id,
-      pendingCookieCount: pendingCookies.length,
-      pendingCookieNames: pendingCookies.map((c) => c.name),
-      requestCookieNames: cookieStore.getAll().map((c) => c.name),
-      supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL,
-      // Don't log full key — just enough to tell legacy anon vs sb_publishable_*
-      publishableKeyPrefix: (
-        process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY ?? ''
-      ).slice(0, 20),
-      forwardedHost: request.headers.get('x-forwarded-host'),
-      origin,
-    });
-  }
+  // Diagnostic context shared by all abnormal branches. Logged to Vercel via
+  // console.error (preserved by next.config.js `removeConsole.exclude`) so a
+  // failing sign-in is fully explained by the URL `reason=` param plus one log
+  // line — no need to turn on DEBUG_AUTH or repro locally.
+  const diag = {
+    hasSession: !!data?.session,
+    hasUser: !!data?.user,
+    pendingCookieCount: pendingCookies.length,
+    pendingCookieNames: pendingCookies.map((c) => c.name),
+    requestCookieNames: cookieStore.getAll().map((c) => c.name),
+    // Just enough of the key to distinguish legacy anon vs sb_publishable_*
+    publishableKeyPrefix: (
+      process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY ?? ''
+    ).slice(0, 20),
+    forwardedHost: request.headers.get('x-forwarded-host'),
+    origin,
+  };
 
   if (error) {
-    console.error('[auth/callback] exchangeCodeForSession failed:', error.message);
+    console.error('[auth/callback] reason=exchange_failed', {
+      ...diag,
+      message: error.message,
+      status: (error as { status?: number } | null)?.status,
+    });
     return clearVerifierAndReturn(
       cookieStore,
       failureRedirect(origin, 'exchange_failed', {
@@ -132,6 +130,7 @@ export async function GET(request: Request) {
   }
 
   if (!data?.session) {
+    console.error('[auth/callback] reason=no_session', diag);
     return clearVerifierAndReturn(
       cookieStore,
       failureRedirect(origin, 'no_session')
@@ -139,6 +138,7 @@ export async function GET(request: Request) {
   }
 
   if (pendingCookies.length === 0) {
+    console.error('[auth/callback] reason=no_pending_cookies', diag);
     return clearVerifierAndReturn(
       cookieStore,
       failureRedirect(origin, 'no_pending_cookies')
@@ -184,24 +184,6 @@ export async function GET(request: Request) {
       ...(cookieDomain ? { domain: cookieDomain } : {}),
     });
   }
-
-  // Short-lived, non-HttpOnly diagnostic cookie. Client JS can read it to
-  // confirm which branch ran, which host we redirected to, and how many
-  // session cookies we attempted to set. Expires in 60s — purely diagnostic.
-  const debugPayload = JSON.stringify({
-    host: publicHost,
-    usedForwardedHost: Boolean(forwardedHost),
-    cookieDomain: cookieDomain ?? null,
-    pendingCookieCount: pendingCookies.length,
-    ts: Date.now(),
-  });
-  response.cookies.set('auth_debug', debugPayload, {
-    path: '/',
-    maxAge: 60,
-    httpOnly: false,
-    sameSite: 'lax',
-    ...(cookieDomain ? { domain: cookieDomain } : {}),
-  });
 
   return response;
 }

--- a/next.config.js
+++ b/next.config.js
@@ -45,11 +45,14 @@ module.exports = {
   },
 
   compiler: {
-    // Strip console.* in prod for performance/security, UNLESS DEBUG_AUTH=1
-    // is set — in which case preserve console.* so the auth callback route's
-    // diagnostic logs survive `pnpm build && pnpm start` for local debugging.
+    // Strip console.log/warn/info/debug in prod for performance and to avoid
+    // leaking internal state, but KEEP console.error so real errors reach
+    // Vercel's runtime logs. Set DEBUG_AUTH=1 to preserve all console.* for
+    // local `pnpm build && pnpm start` repro of auth flows.
     removeConsole:
-      process.env.NODE_ENV === 'production' && process.env.DEBUG_AUTH !== '1',
+      process.env.NODE_ENV === 'production' && process.env.DEBUG_AUTH !== '1'
+        ? { exclude: ['error'] }
+        : false,
   },
 
   // Image optimization settings


### PR DESCRIPTION
## Summary

Follow-up cleanup for the OAuth session-cookie saga. Now that #841 has proven the pipeline end-to-end, the browser-side `auth_debug` cookie from #840 is no longer earning its keep. Replacing it with server-side error logs that land in Vercel's runtime log viewer: zero client footprint, no leaked deployment details to analytics/session-replay scripts, and full context when things actually go wrong.

## What changed

### `next.config.js`

`removeConsole` in prod now uses `{ exclude: ['error'] }` instead of stripping everything.

```js
// before
removeConsole: process.env.NODE_ENV === 'production' && process.env.DEBUG_AUTH !== '1'

// after
removeConsole:
  process.env.NODE_ENV === 'production' && process.env.DEBUG_AUTH !== '1'
    ? { exclude: ['error'] }
    : false
```

`console.log/warn/info/debug` are still stripped. `console.error` survives — so real errors from anywhere in the app reach Vercel's runtime logs. `DEBUG_AUTH=1` continues to disable stripping entirely for local `pnpm build && pnpm start` auth-flow repro.

### `app/auth/callback/route.ts`

- **Shared `diag` object** captures the same fields the `auth_debug` cookie carried (`forwardedHost`, `pendingCookieCount`, `pendingCookieNames`, `requestCookieNames`, `publishableKeyPrefix`, `origin`) plus SDK-side signals (`hasSession`, `hasUser`).
- **Every abnormal branch logs** `[auth/callback] reason=<branch>` with `diag` via `console.error`:
  - `exchange_failed` — adds SDK `message` + `status`
  - `no_session`
  - `no_pending_cookies`
- **`no_code` is not logged** — crawler/direct-URL hits, would be noise.
- **`auth_debug` cookie + `debugPayload`** construction removed from the success path.
- **`DEBUG_AUTH`-gated `console.log` block removed** — its content was a subset of `diag` and only fires now when something is actually wrong, which is when you'd want it anyway.
- **`oauth_error`** removed from `failureRedirect`'s reason union — it was never passed (the GoTrue error path uses a different redirect).

## What you'll see in Vercel's log viewer on a future failing sign-in

```
[auth/callback] reason=no_pending_cookies {
  hasSession: true,
  hasUser: true,
  pendingCookieCount: 0,
  pendingCookieNames: [],
  requestCookieNames: [ 'sb-ilwqylsdqacxmfkisclx-auth-token-code-verifier' ],
  publishableKeyPrefix: 'sb_publishable_aBcDeF',
  forwardedHost: 'www.omshub.org',
  origin: 'https://some-internal-vercel-lb.vercel.app'
}
```

Successful sign-ins log nothing. Clean and silent.

## Non-goals

- Does **not** change any success-path behavior — cookies still stamped with `Domain=omshub.org` (from #840), still redirected via `x-forwarded-host` (from #835).
- Does **not** touch `AuthErrorNotification`, `page.tsx`, or the `reason=` URL params — those stay useful and visible to the end user.

## Test plan

- [ ] CI green
- [ ] Preview sign-in on Google still works (expect no `?error=`, welcome toast, session cookies on `Domain=<preview-host>`)
- [ ] Preview DevTools → Cookies: no `auth_debug` cookie present anymore
- [ ] Force a failure (e.g., navigate to `/auth/callback?code=bogus` on the preview) → URL gets `?reason=exchange_failed&message=…`, Vercel log viewer shows one `[auth/callback] reason=exchange_failed {…}` error line

## Rollback

Revert this commit. No schema, env, or API changes.

## Related

- #830, #832, #833, #835 — prior callback fixes (all needed, all still in place)
- #840 — diagnostic patch that made this bug legible (reason= params kept, auth_debug cookie retired here)
- #841 — `@supabase/ssr` upgrade, the actual root-cause fix