### PR TITLE
fix(schedule): keep current semester selected

### DIFF
--- a/app/schedule/ScheduleContent.integration.test.ts
+++ b/app/schedule/ScheduleContent.integration.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+describe('schedule content future semester probing', () => {
+  const source = readFileSync(join(process.cwd(), 'app/schedule/_components/ScheduleContent.tsx'), 'utf8');
+
+  it('uses the shared semester options helper when future terms are discovered', () => {
+    expect(source).toContain('setSemesters(getScheduleSemesterOptions(pastSemesters, available));');
+  });
+
+  it('does not change the active semester from the future-term probe', () => {
+    const probeEffect = source.match(/async function probeFutureSemesters\(\) \{[\s\S]*?\n    \}\n\n    probeFutureSemesters\(\);/);
+
+    expect(probeEffect?.[0]).toBeDefined();
+    expect(probeEffect?.[0]).not.toContain('setActiveSemester');
+  });
+});

--- a/app/schedule/_components/ScheduleContent.tsx
+++ b/app/schedule/_components/ScheduleContent.tsx
@@ -39,6 +39,15 @@ import {
   IconCheck,
 } from '@tabler/icons-react';
 import { GT_COLORS } from '@/lib/theme';
+import {
+  getCurrentSemester,
+  getFutureCandidates,
+  getInitialActiveSemester,
+  getPastSemesters,
+  getScheduleSemesterOptions,
+  getTermCode,
+  getTermLabel,
+} from '../_lib/semesters';
 
 // Data repository URL
 const DATA_REPO_BASE = 'https://raw.githubusercontent.com/omshub/data/main';
@@ -143,88 +152,6 @@ interface CourseSection {
   url: string | null;
 }
 
-// Term code utilities
-function getTermCode(year: number, semester: 'sp' | 'sm' | 'fa'): string {
-  const semesterCodes = { sp: '02', sm: '05', fa: '08' };
-  return `${year}${semesterCodes[semester]}`;
-}
-
-function parseTermCode(termCode: string): { year: number; semester: string } {
-  const year = parseInt(termCode.substring(0, 4));
-  const semCode = termCode.substring(4);
-  const semesterMap: Record<string, string> = { '02': 'Spring', '05': 'Summer', '08': 'Fall' };
-  return { year, semester: semesterMap[semCode] || 'Unknown' };
-}
-
-function getTermLabel(termCode: string): string {
-  const { year, semester } = parseTermCode(termCode);
-  return `${semester} ${year}`;
-}
-
-// Get current semester based on month
-function getCurrentSemester(): { year: number; semester: 'sp' | 'sm' | 'fa' } {
-  const now = new Date();
-  const month = now.getMonth() + 1; // 1-12
-  const year = now.getFullYear();
-
-  if (month >= 1 && month <= 4) {
-    return { year, semester: 'sp' }; // Spring: Jan-Apr
-  } else if (month >= 5 && month <= 7) {
-    return { year, semester: 'sm' }; // Summer: May-Jul
-  } else {
-    return { year, semester: 'fa' }; // Fall: Aug-Dec
-  }
-}
-
-// Past semesters from current back to 2014, most recent first
-function getPastSemesters(): { value: string; label: string }[] {
-  const { year: currentYear, semester: currentSem } = getCurrentSemester();
-  const semesters: { value: string; label: string }[] = [];
-  const semesterOrder: ('sp' | 'sm' | 'fa')[] = ['sp', 'sm', 'fa'];
-  const startYear = 2014; // OMSCS program started
-
-  let year = currentYear;
-  let semIndex = semesterOrder.indexOf(currentSem);
-
-  while (year >= startYear) {
-    const sem = semesterOrder[semIndex];
-    const semLabel = sem === 'sp' ? 'Spring' : sem === 'sm' ? 'Summer' : 'Fall';
-    semesters.push({
-      value: getTermCode(year, sem),
-      label: `${semLabel} ${year}`,
-    });
-
-    semIndex--;
-    if (semIndex < 0) {
-      semIndex = 2;
-      year--;
-    }
-  }
-
-  return semesters;
-}
-
-// Returns the next N future term codes after the current semester
-function getFutureCandidates(n: number): string[] {
-  const { year: currentYear, semester: currentSem } = getCurrentSemester();
-  const semesterOrder: ('sp' | 'sm' | 'fa')[] = ['sp', 'sm', 'fa'];
-  const candidates: string[] = [];
-
-  let year = currentYear;
-  let semIndex = semesterOrder.indexOf(currentSem);
-
-  for (let i = 0; i < n; i++) {
-    semIndex++;
-    if (semIndex >= semesterOrder.length) {
-      semIndex = 0;
-      year++;
-    }
-    candidates.push(getTermCode(year, semesterOrder[semIndex]));
-  }
-
-  return candidates;
-}
-
 interface StatCardProps {
   icon: React.ReactNode;
   value: string | number;
@@ -311,7 +238,7 @@ function getSearchScore(section: CourseSection, query: string): number {
 export default function ScheduleContent() {
   const pastSemesters = useMemo(() => getPastSemesters(), []);
   const [semesters, setSemesters] = useState(pastSemesters);
-  const [activeSemester, setActiveSemester] = useState(pastSemesters[0]?.value || '');
+  const [activeSemester, setActiveSemester] = useState(getInitialActiveSemester(pastSemesters));
   const [searchQuery, setSearchQuery] = useState('');
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -338,12 +265,7 @@ export default function ScheduleContent() {
 
       const available = results.filter((t): t is string => t !== null);
       if (available.length > 0) {
-        const futureOptions = available.map((termCode) => ({
-          value: termCode,
-          label: getTermLabel(termCode),
-        }));
-        setSemesters([...futureOptions, ...pastSemesters]);
-        setActiveSemester(futureOptions[0].value);
+        setSemesters(getScheduleSemesterOptions(pastSemesters, available));
       }
     }
 
@@ -351,11 +273,8 @@ export default function ScheduleContent() {
   }, [pastSemesters]);
 
   useEffect(() => {
-    // Cancellation flag: the probe effect can change activeSemester mid-fetch,
-    // triggering a second run of this effect. Without this guard, a slower
-    // earlier fetch can land after the newer one and overwrite fresh data with
-    // the previous semester's rows — producing the "Summer 2026 shows Spring 2026
-    // enrollment" hydration artifact reported on Slack.
+    // Cancellation flag: if activeSemester changes while a fetch is in flight,
+    // a slower earlier request must not overwrite the newer semester's rows.
     let cancelled = false;
 
     async function fetchData() {

--- a/app/schedule/_lib/semesters.test.ts
+++ b/app/schedule/_lib/semesters.test.ts
@@ -1,0 +1,91 @@
+import {
+  getCurrentSemester,
+  getFutureCandidates,
+  getInitialActiveSemester,
+  getPastSemesters,
+  getScheduleSemesterOptions,
+  getTermCode,
+  getTermLabel,
+} from './semesters';
+
+describe('schedule semester helpers', () => {
+  it('maps semester term codes and labels', () => {
+    expect(getTermCode(2026, 'sp')).toBe('202602');
+    expect(getTermCode(2026, 'sm')).toBe('202605');
+    expect(getTermCode(2026, 'fa')).toBe('202608');
+    expect(getTermLabel('202605')).toBe('Summer 2026');
+  });
+
+  const currentSemesterCases = [
+    ['2026-01-01T18:00:00Z', { year: 2026, semester: 'sp' }],
+    ['2026-01-15T12:00:00Z', { year: 2026, semester: 'sp' }],
+    ['2026-04-30T18:00:00Z', { year: 2026, semester: 'sp' }],
+    ['2026-05-01T18:00:00Z', { year: 2026, semester: 'sm' }],
+    ['2026-05-06T12:00:00Z', { year: 2026, semester: 'sm' }],
+    ['2026-07-31T18:00:00Z', { year: 2026, semester: 'sm' }],
+    ['2026-08-01T18:00:00Z', { year: 2026, semester: 'fa' }],
+    ['2026-08-01T12:00:00Z', { year: 2026, semester: 'fa' }],
+    ['2026-12-31T18:00:00Z', { year: 2026, semester: 'fa' }],
+  ] as const;
+
+  currentSemesterCases.forEach(([date, expected]) => {
+    it(`selects the current semester for ${date}`, () => {
+      expect(getCurrentSemester(new Date(date))).toEqual(expected);
+    });
+  });
+
+  it('builds past semesters from the current semester back to the program start', () => {
+    const semesters = getPastSemesters(new Date('2026-05-06T12:00:00Z'));
+
+    expect(semesters.slice(0, 4)).toEqual([
+      { value: '202605', label: 'Summer 2026' },
+      { value: '202602', label: 'Spring 2026' },
+      { value: '202508', label: 'Fall 2025' },
+      { value: '202505', label: 'Summer 2025' },
+    ]);
+    expect(semesters.at(-1)).toEqual({ value: '201402', label: 'Spring 2014' });
+  });
+
+  it('probes only future semesters after the active current semester', () => {
+    expect(getFutureCandidates(3, new Date('2026-05-06T12:00:00Z'))).toEqual([
+      '202608',
+      '202702',
+      '202705',
+    ]);
+  });
+
+  it('wraps future semester candidates across year boundaries', () => {
+    expect(getFutureCandidates(3, new Date('2026-11-01T12:00:00Z'))).toEqual([
+      '202702',
+      '202705',
+      '202708',
+    ]);
+  });
+
+  it('keeps the current semester active when future semesters are available', () => {
+    const currentDate = new Date('2026-05-06T12:00:00Z');
+    const pastSemesters = getPastSemesters(currentDate);
+
+    const semesters = getScheduleSemesterOptions(pastSemesters, ['202608']);
+
+    expect(getInitialActiveSemester(pastSemesters)).toBe('202605');
+    expect(semesters.slice(0, 2)).toEqual([
+      { value: '202608', label: 'Fall 2026' },
+      { value: '202605', label: 'Summer 2026' },
+    ]);
+  });
+
+  it('deduplicates discovered future terms that are already in the base semester list', () => {
+    const pastSemesters = getPastSemesters(new Date('2026-05-06T12:00:00Z'));
+
+    const semesters = getScheduleSemesterOptions(pastSemesters, ['202608', '202605', '202608']);
+
+    expect(semesters.filter((semester) => semester.value === '202608')).toHaveLength(1);
+    expect(semesters.filter((semester) => semester.value === '202605')).toHaveLength(1);
+  });
+
+  it('falls back to no active semester when no base semesters exist', () => {
+    expect(getInitialActiveSemester([])).toBe('');
+    expect(getScheduleSemesterOptions([], ['202608'])).toEqual([{ value: '202608', label: 'Fall 2026' }]);
+  });
+});

--- a/app/schedule/_lib/semesters.ts
+++ b/app/schedule/_lib/semesters.ts
@@ -1,0 +1,99 @@
+export type SemesterCode = 'sp' | 'sm' | 'fa';
+
+export interface SemesterOption {
+  value: string;
+  label: string;
+}
+
+export function getTermCode(year: number, semester: SemesterCode): string {
+  const semesterCodes = { sp: '02', sm: '05', fa: '08' };
+  return `${year}${semesterCodes[semester]}`;
+}
+
+export function parseTermCode(termCode: string): { year: number; semester: string } {
+  const year = parseInt(termCode.substring(0, 4));
+  const semCode = termCode.substring(4);
+  const semesterMap: Record<string, string> = { '02': 'Spring', '05': 'Summer', '08': 'Fall' };
+  return { year, semester: semesterMap[semCode] || 'Unknown' };
+}
+
+export function getTermLabel(termCode: string): string {
+  const { year, semester } = parseTermCode(termCode);
+  return `${semester} ${year}`;
+}
+
+export function getCurrentSemester(now = new Date()): { year: number; semester: SemesterCode } {
+  const month = now.getMonth() + 1;
+  const year = now.getFullYear();
+
+  if (month >= 1 && month <= 4) {
+    return { year, semester: 'sp' };
+  }
+  if (month >= 5 && month <= 7) {
+    return { year, semester: 'sm' };
+  }
+  return { year, semester: 'fa' };
+}
+
+export function getPastSemesters(now = new Date()): SemesterOption[] {
+  const { year: currentYear, semester: currentSem } = getCurrentSemester(now);
+  const semesters: SemesterOption[] = [];
+  const semesterOrder: SemesterCode[] = ['sp', 'sm', 'fa'];
+  const startYear = 2014;
+
+  let year = currentYear;
+  let semIndex = semesterOrder.indexOf(currentSem);
+
+  while (year >= startYear) {
+    const sem = semesterOrder[semIndex];
+    semesters.push({
+      value: getTermCode(year, sem),
+      label: getTermLabel(getTermCode(year, sem)),
+    });
+
+    semIndex--;
+    if (semIndex < 0) {
+      semIndex = 2;
+      year--;
+    }
+  }
+
+  return semesters;
+}
+
+export function getFutureCandidates(n: number, now = new Date()): string[] {
+  const { year: currentYear, semester: currentSem } = getCurrentSemester(now);
+  const semesterOrder: SemesterCode[] = ['sp', 'sm', 'fa'];
+  const candidates: string[] = [];
+
+  let year = currentYear;
+  let semIndex = semesterOrder.indexOf(currentSem);
+
+  for (let i = 0; i < n; i++) {
+    semIndex++;
+    if (semIndex >= semesterOrder.length) {
+      semIndex = 0;
+      year++;
+    }
+    candidates.push(getTermCode(year, semesterOrder[semIndex]));
+  }
+
+  return candidates;
+}
+
+export function getInitialActiveSemester(baseSemesters: SemesterOption[]): string {
+  return baseSemesters[0]?.value || '';
+}
+
+export function getScheduleSemesterOptions(baseSemesters: SemesterOption[], availableFutureTermCodes: string[]): SemesterOption[] {
+  const seen = new Set(baseSemesters.map((semester) => semester.value));
+  const futureOptions = availableFutureTermCodes
+    .filter((termCode, index, allTermCodes) => allTermCodes.indexOf(termCode) === index)
+    .filter((termCode) => !seen.has(termCode))
+    .map((termCode) => ({
+      value: termCode,
+      label: getTermLabel(termCode),
+    }));
+
+  return [...futureOptions, ...baseSemesters];
+}

--- a/app/schedule/jest-globals.d.ts
+++ b/app/schedule/jest-globals.d.ts
@@ -1,0 +1,20 @@
+declare const describe: (name: string, fn: () => void) => void;
+
+interface JestIt {
+  (name: string, fn: () => void): void;
+}
+
+declare const it: JestIt;
+
+interface JestExpectation {
+  not: {
+    toContain(expected: unknown): void;
+  };
+  toBe(expected: unknown): void;
+  toBeDefined(): void;
+  toContain(expected: unknown): void;
+  toEqual(expected: unknown): void;
+  toHaveLength(expected: number): void;
+}
+
+declare const expect: (actual: unknown) => JestExpectation;


### PR DESCRIPTION
## Summary
- keep the schedule page defaulted to the current semester even when future-term data exists
- still prepend available future semesters to the dropdown so users can select them manually
- extract schedule semester helpers and add regression coverage for term boundaries, future probes, deduping, and active-semester behavior

## Root cause
The future-semester probe prepended future terms and also called `setActiveSemester(futureOptions[0].value)`. Once Fall 2026 data appeared, the page silently switched from Summer 2026 to Fall 2026, where many rows had early-registration enrollment values like `0`.

## Verification
- `pnpm test:ci --runInBand`
- `pnpm lint` (0 errors; existing warnings in `src/components/ReviewCard.tsx` and `src/components/analytics/MicrosoftClarity.tsx`)
- `pnpm build`
- `pnpm test:ci --runTestsByPath app/schedule/_lib/semesters.test.ts app/schedule/ScheduleContent.integration.test.ts app/schedule/page.lazy.test.ts`
