### PR TITLE
Add sticky table headers

### DIFF
--- a/app/_components/CoursesTable.test.ts
+++ b/app/_components/CoursesTable.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+describe('CoursesTable', () => {
+  const source = readFileSync(
+    join(process.cwd(), 'app/_components/CoursesTable.tsx'),
+    'utf8'
+  );
+
+  it('keeps table headers sticky while scrolling the course list', () => {
+    expect(source).toContain('stickyHeader');
+    expect(source).toContain('stickyHeaderOffset={72}');
+  });
+});

--- a/app/_components/CoursesTable.tsx
+++ b/app/_components/CoursesTable.tsx
@@ -202,9 +202,15 @@ export default function CoursesTable({ allCourseData }: CoursesTableProps) {
         </Text>
       </Box>
 
-      <Paper radius="lg" withBorder style={{ overflow: 'auto' }}>
+      <Paper radius="lg" withBorder>
         <Table.ScrollContainer minWidth={700}>
-          <Table verticalSpacing="sm" highlightOnHover style={{ minWidth: 700 }}>
+          <Table
+            verticalSpacing="sm"
+            highlightOnHover
+            stickyHeader
+            stickyHeaderOffset={72}
+            style={{ minWidth: 700 }}
+          >
             <Table.Thead style={{ backgroundColor: GT_COLORS.navy }}>
               <Table.Tr>
                 <Th

--- a/app/schedule/_components/ScheduleContent.test.ts
+++ b/app/schedule/_components/ScheduleContent.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+describe('ScheduleContent', () => {
+  const source = readFileSync(
+    join(process.cwd(), 'app/schedule/_components/ScheduleContent.tsx'),
+    'utf8'
+  );
+
+  it('keeps table headers sticky while scrolling the schedule list', () => {
+    expect(source).toContain('stickyHeader');
+    expect(source).toContain('stickyHeaderOffset={72}');
+  });
+});

--- a/app/schedule/_components/ScheduleContent.tsx
+++ b/app/schedule/_components/ScheduleContent.tsx
@@ -724,7 +724,12 @@ export default function ScheduleContent() {
   // Reusable table component
   const renderTable = (sectionsList: CourseSection[], showCoreElectiveBadge = false) => (
     <Table.ScrollContainer minWidth={800}>
-      <Table verticalSpacing="sm" highlightOnHover>
+      <Table
+        verticalSpacing="sm"
+        highlightOnHover
+        stickyHeader
+        stickyHeaderOffset={72}
+      >
         <Table.Thead style={{ backgroundColor: GT_COLORS.navy }}>
           <Table.Tr>
             <Table.Th style={{ color: 'white' }}>CRN</Table.Th>
@@ -937,7 +942,7 @@ export default function ScheduleContent() {
                     {new Set(groupedSections.core.map((s) => s.courseId)).size} courses
                   </Badge>
                 </Group>
-                <Paper radius="lg" withBorder style={{ overflow: 'hidden' }}>
+                <Paper radius="lg" withBorder>
                   {renderTable(groupedSections.core)}
                 </Paper>
               </div>
@@ -957,7 +962,7 @@ export default function ScheduleContent() {
                     {new Set(groupedSections.electives.map((s) => s.courseId)).size} courses
                   </Badge>
                 </Group>
-                <Paper radius="lg" withBorder style={{ overflow: 'hidden' }}>
+                <Paper radius="lg" withBorder>
                   {renderTable(groupedSections.electives)}
                 </Paper>
               </div>
@@ -977,7 +982,7 @@ export default function ScheduleContent() {
                     {new Set(groupedSections.freeElectives.map((s) => s.courseId)).size} courses
                   </Badge>
                 </Group>
-                <Paper radius="lg" withBorder style={{ overflow: 'hidden' }}>
+                <Paper radius="lg" withBorder>
                   {renderTable(groupedSections.freeElectives)}
                 </Paper>
               </div>
@@ -1004,7 +1009,7 @@ export default function ScheduleContent() {
           </Stack>
         ) : (
           // Default ungrouped view
-          <Paper radius="lg" withBorder style={{ overflow: 'hidden' }}>
+          <Paper radius="lg" withBorder>
             {renderTable(filteredAndSortedSections)}
           </Paper>
         )}


### PR DESCRIPTION
## Summary
- add Mantine sticky headers to the main course table on `/`
- add Mantine sticky headers to the schedule tables on `/schedule`
- add regression coverage for both table render sites

Closes #834

## Verification
- `pnpm test:ci --runTestsByPath app/page.lazy.test.ts app/schedule/page.lazy.test.ts app/_components/CoursesTable.test.ts app/schedule/_components/ScheduleContent.test.ts`
- `pnpm exec eslint app/_components/CoursesTable.tsx app/_components/CoursesTable.test.ts app/schedule/_components/ScheduleContent.tsx app/schedule/_components/ScheduleContent.test.ts`
- `pnpm build`
- `git push -u origin sticky-table-headers` ran the pre-push `pnpm build` hook successfully

## Notes
- Browser smoke verification against local dev was blocked by missing Supabase env values and an unrelated local React/react-dom dev mismatch, so this PR relies on focused tests plus production build verification.
