### PR TITLE
fix: repair table rendering

### DIFF
--- a/app/_components/CoursesTable.test.ts
+++ b/app/_components/CoursesTable.test.ts
@@ -7,8 +7,9 @@ describe('CoursesTable', () => {
     'utf8'
   );
 
-  it('keeps table headers sticky while scrolling the course list', () => {
-    expect(source).toContain('stickyHeader');
-    expect(source).toContain('stickyHeaderOffset={72}');
+  it('renders course tables without a sticky header offset gap', () => {
+    expect(source).not.toContain('stickyHeader');
+    expect(source).not.toContain('stickyHeaderOffset');
+    expect(source).toContain('type="native"');
   });
 });

--- a/app/_components/CoursesTable.tsx
+++ b/app/_components/CoursesTable.tsx
@@ -203,12 +203,10 @@ export default function CoursesTable({ allCourseData }: CoursesTableProps) {
       </Box>
 
       <Paper radius="lg" withBorder>
-        <Table.ScrollContainer minWidth={700}>
+        <Table.ScrollContainer minWidth={700} type="native">
           <Table
             verticalSpacing="sm"
             highlightOnHover
-            stickyHeader
-            stickyHeaderOffset={72}
             style={{ minWidth: 700 }}
           >
             <Table.Thead style={{ backgroundColor: GT_COLORS.navy }}>

--- a/app/availability/AvailabilityContent.tsx
+++ b/app/availability/AvailabilityContent.tsx
@@ -466,7 +466,7 @@ export default function AvailabilityContent() {
               <Loader color={GT_COLORS.techGold} />
             </Center>
           ) : (
-            <Table.ScrollContainer minWidth={800}>
+            <Table.ScrollContainer minWidth={800} type="native">
               <Table verticalSpacing="sm" highlightOnHover>
                 <Table.Thead style={{ backgroundColor: GT_COLORS.navy }}>
                   <Table.Tr>

--- a/app/schedule/_components/ScheduleContent.test.ts
+++ b/app/schedule/_components/ScheduleContent.test.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { getDisplayedScheduleSections, getGroupedScheduleSections } from './ScheduleContent';
 
 describe('ScheduleContent', () => {
   const source = readFileSync(
@@ -7,8 +8,51 @@ describe('ScheduleContent', () => {
     'utf8'
   );
 
-  it('keeps table headers sticky while scrolling the schedule list', () => {
-    expect(source).toContain('stickyHeader');
-    expect(source).toContain('stickyHeaderOffset={72}');
+  it('renders schedule tables without a sticky header offset gap', () => {
+    expect(source).not.toContain('stickyHeader');
+    expect(source).not.toContain('stickyHeaderOffset');
+    expect(source).not.toContain('Table.ScrollContainer');
+    expect(source).not.toContain('aria-hidden="true" role="row"');
+    expect(source).not.toContain('boxShadow');
+    expect(source).not.toContain("var(--mantine-color-dark-7)");
+    expect(source).toContain('const tableHeaderBackground = GT_COLORS.navy');
+    expect(source).toContain('const tableHeaderBorderColor = GT_COLORS.techGold');
+    expect(source).toContain("const tableBorderColor = 'var(--mantine-color-default-border)'");
+    expect(source).toContain("overflowX: 'auto'");
+    expect(source).toContain('getScheduleTablePaperProps');
+    expect(source).toContain('getScheduleHeaderCellStyle');
+  });
+
+  it('excludes unrelated courses when a specialization filter is selected', () => {
+    const sections = [
+      { courseId: 'CS-6515', crn: '1' },
+      { courseId: 'CS-6601', crn: '2' },
+      { courseId: 'CS-6200', crn: '3' },
+    ];
+
+    const grouped = getGroupedScheduleSections(
+      sections as never,
+      { specializationId: 'cs:ai', name: 'Artificial Intelligence', programId: 'cs' },
+      new Set(['CS-6515']),
+      new Set(['CS-6601'])
+    );
+
+    expect(grouped.core).toEqual([sections[0]]);
+    expect(grouped.electives).toEqual([sections[1]]);
+    expect(grouped.freeElectives).toEqual([]);
+  });
+
+  it('counts only displayed specialization rows', () => {
+    const grouped = {
+      all: [],
+      core: [{ courseId: 'CS-6515', crn: '1' }],
+      electives: [{ courseId: 'CS-6601', crn: '2' }],
+      freeElectives: [],
+    };
+
+    expect(getDisplayedScheduleSections(grouped as never)).toEqual([
+      grouped.core[0],
+      grouped.electives[0],
+    ]);
   });
 });

--- a/app/schedule/_components/ScheduleContent.tsx
+++ b/app/schedule/_components/ScheduleContent.tsx
@@ -5,7 +5,6 @@ import {
   Container,
   Title,
   Text,
-  Table,
   Badge,
   Paper,
   Group,
@@ -157,6 +156,72 @@ interface StatCardProps {
   value: string | number;
   label: string;
   color: string;
+}
+
+interface GroupedScheduleSections {
+  all: CourseSection[];
+  core: CourseSection[];
+  electives: CourseSection[];
+  freeElectives: CourseSection[];
+}
+
+const tableHeaderBackground = GT_COLORS.navy;
+const tableHeaderBorderColor = GT_COLORS.techGold;
+const tableBorderColor = 'var(--mantine-color-default-border)';
+const scheduleTableHeaderHeight = 72;
+const scheduleTableColumns = '120px 90px minmax(360px, 1.8fr) minmax(200px, 1fr) 150px 90px';
+
+export function getScheduleTablePaperProps() {
+  return {
+    radius: 'lg' as const,
+    withBorder: true,
+    style: {
+      overflow: 'hidden',
+    },
+  };
+}
+
+export function getScheduleHeaderCellStyle(textAlign?: React.CSSProperties['textAlign']): React.CSSProperties {
+  return {
+    backgroundColor: tableHeaderBackground,
+    color: 'white',
+    position: 'relative',
+    textAlign,
+    zIndex: 2,
+  };
+}
+
+export function getGroupedScheduleSections(
+  filteredSections: CourseSection[],
+  selectedSpec: Specialization | null,
+  coreCourseIds: Set<string>,
+  electiveCourseIds: Set<string>
+): GroupedScheduleSections {
+  if (!selectedSpec) {
+    return { all: filteredSections || [], core: [], electives: [], freeElectives: [] };
+  }
+
+  const core: CourseSection[] = [];
+  const electives: CourseSection[] = [];
+
+  (filteredSections || []).forEach((section) => {
+    if (coreCourseIds.has(section.courseId)) {
+      core.push(section);
+    } else if (electiveCourseIds.has(section.courseId)) {
+      electives.push(section);
+    }
+  });
+
+  return { all: [], core, electives, freeElectives: [] };
+}
+
+export function getDisplayedScheduleSections(groupedSections: GroupedScheduleSections) {
+  return [
+    ...(groupedSections.all || []),
+    ...(groupedSections.core || []),
+    ...(groupedSections.electives || []),
+    ...(groupedSections.freeElectives || []),
+  ];
 }
 
 function StatCard({ icon, value, label, color }: StatCardProps) {
@@ -445,27 +510,9 @@ export default function ScheduleContent() {
 
   // Group sections by core/elective/free when specialization is selected
   const groupedSections = useMemo(() => {
-
-    if (!selectedSpec) {
-      return { all: filteredAndSortedSections || [] };
-    }
-
-    const core: CourseSection[] = [];
-    const electives: CourseSection[] = [];
-    const freeElectives: CourseSection[] = [];
-
-    (filteredAndSortedSections || []).forEach((section) => {
-      if (coreCourseIds.has(section.courseId)) {
-        core.push(section);
-      } else if (electiveCourseIds.has(section.courseId)) {
-        electives.push(section);
-      } else {
-        freeElectives.push(section);
-      }
-    });
-
-    return { core, electives, freeElectives };
+    return getGroupedScheduleSections(filteredAndSortedSections, selectedSpec, coreCourseIds, electiveCourseIds);
   }, [filteredAndSortedSections, selectedSpec, coreCourseIds, electiveCourseIds]);
+  const displayedSections = useMemo(() => getDisplayedScheduleSections(groupedSections), [groupedSections]);
 
   // Calculate stats
   const safeSections = sections || [];
@@ -524,8 +571,18 @@ export default function ScheduleContent() {
     const regStatus = getRegistrationStatus(section);
 
     return (
-    <Table.Tr key={`${section.crn}-${section.sectionNumber}`}>
-      <Table.Td>
+    <Box
+      key={`${section.crn}-${section.sectionNumber}`}
+      role="row"
+      style={{
+        display: 'grid',
+        gridTemplateColumns: scheduleTableColumns,
+        alignItems: 'center',
+        borderBottom: '1px solid var(--table-border-color, var(--mantine-color-dark-4))',
+        minHeight: 74,
+      }}
+    >
+      <Box role="cell" px="sm" py="sm">
         <Group gap={4} wrap="nowrap">
           <Badge variant="filled" size="sm" color="dark">
             {section.crn}
@@ -546,9 +603,9 @@ export default function ScheduleContent() {
             )}
           </CopyButton>
         </Group>
-      </Table.Td>
+      </Box>
       {isCurrentSemester && (
-        <Table.Td ta="center">
+        <Box role="cell" px="sm" py="sm" ta="center">
           <Tooltip label={regStatus.description}>
             <Badge
               variant="filled"
@@ -558,9 +615,9 @@ export default function ScheduleContent() {
               {regStatus.status}
             </Badge>
           </Tooltip>
-        </Table.Td>
+        </Box>
       )}
-      <Table.Td>
+      <Box role="cell" px="sm" py="sm">
         <Stack gap={4}>
           <Group gap="xs">
             {section.url ? (
@@ -604,11 +661,11 @@ export default function ScheduleContent() {
             {section.name}
           </Text>
         </Stack>
-      </Table.Td>
-      <Table.Td>
+      </Box>
+      <Box role="cell" px="sm" py="sm">
         <Text size="sm">{section.instructor}</Text>
-      </Table.Td>
-      <Table.Td>
+      </Box>
+      <Box role="cell" px="sm" py="sm">
         <Stack gap={4} w={120}>
           <Group justify="space-between">
             <Text size="xs" c="dimmed">
@@ -626,8 +683,8 @@ export default function ScheduleContent() {
             />
           </Progress.Root>
         </Stack>
-      </Table.Td>
-      <Table.Td ta="center">
+      </Box>
+      <Box role="cell" px="sm" py="sm" ta="center">
         {section.waitlist > 0 ? (
           <Badge variant="filled" size="sm" style={{ backgroundColor: '#7a5d00', color: 'white' }}>
             {section.waitlist}
@@ -635,35 +692,45 @@ export default function ScheduleContent() {
         ) : (
           <Text size="sm" c="dimmed">-</Text>
         )}
-      </Table.Td>
-    </Table.Tr>
+      </Box>
+    </Box>
     );
   };
 
   // Reusable table component
   const renderTable = (sectionsList: CourseSection[], showCoreElectiveBadge = false) => (
-    <Table.ScrollContainer minWidth={800}>
-      <Table
-        verticalSpacing="sm"
-        highlightOnHover
-        stickyHeader
-        stickyHeaderOffset={72}
+    <Box style={{ overflowX: 'auto' }}>
+      <Box
+        role="table"
+        style={{
+          minWidth: 800,
+          ['--table-border-color' as string]: tableBorderColor,
+          ['--table-header-border-color' as string]: tableHeaderBorderColor,
+        }}
       >
-        <Table.Thead style={{ backgroundColor: GT_COLORS.navy }}>
-          <Table.Tr>
-            <Table.Th style={{ color: 'white' }}>CRN</Table.Th>
-            {isCurrentSemester && <Table.Th style={{ color: 'white', textAlign: 'center' }}>Status</Table.Th>}
-            <Table.Th style={{ color: 'white' }}>Course</Table.Th>
-            <Table.Th style={{ color: 'white' }}>Instructor</Table.Th>
-            <Table.Th style={{ color: 'white', textAlign: 'center' }}>Enrollment</Table.Th>
-            <Table.Th style={{ color: 'white', textAlign: 'center' }}>Waitlist</Table.Th>
-          </Table.Tr>
-        </Table.Thead>
-        <Table.Tbody>
+        <Box
+          role="row"
+          style={{
+            display: 'grid',
+            gridTemplateColumns: scheduleTableColumns,
+            alignItems: 'center',
+            minHeight: scheduleTableHeaderHeight,
+            borderBottom: '2px solid var(--table-header-border-color)',
+            backgroundColor: tableHeaderBackground,
+          }}
+        >
+          <Box role="columnheader" px="sm" py="sm" style={getScheduleHeaderCellStyle()}>CRN</Box>
+          {isCurrentSemester && <Box role="columnheader" px="sm" py="sm" style={getScheduleHeaderCellStyle('center')}>Status</Box>}
+          <Box role="columnheader" px="sm" py="sm" style={getScheduleHeaderCellStyle()}>Course</Box>
+          <Box role="columnheader" px="sm" py="sm" style={getScheduleHeaderCellStyle()}>Instructor</Box>
+          <Box role="columnheader" px="sm" py="sm" style={getScheduleHeaderCellStyle('center')}>Enrollment</Box>
+          <Box role="columnheader" px="sm" py="sm" style={getScheduleHeaderCellStyle('center')}>Waitlist</Box>
+        </Box>
+        <Box role="rowgroup">
           {(sectionsList || []).map((section) => renderSectionRow(section, showCoreElectiveBadge))}
-        </Table.Tbody>
-      </Table>
-    </Table.ScrollContainer>
+        </Box>
+      </Box>
+    </Box>
   );
 
   return (
@@ -813,7 +880,7 @@ export default function ScheduleContent() {
             </Group>
           </div>
           <Badge variant="filled" color="dark" size="lg">
-            {filteredAndSortedSections.length} sections
+            {displayedSections.length} sections
           </Badge>
         </Group>
 
@@ -861,7 +928,7 @@ export default function ScheduleContent() {
                     {new Set(groupedSections.core.map((s) => s.courseId)).size} courses
                   </Badge>
                 </Group>
-                <Paper radius="lg" withBorder>
+                <Paper {...getScheduleTablePaperProps()}>
                   {renderTable(groupedSections.core)}
                 </Paper>
               </div>
@@ -881,28 +948,8 @@ export default function ScheduleContent() {
                     {new Set(groupedSections.electives.map((s) => s.courseId)).size} courses
                   </Badge>
                 </Group>
-                <Paper radius="lg" withBorder>
+                <Paper {...getScheduleTablePaperProps()}>
                   {renderTable(groupedSections.electives)}
-                </Paper>
-              </div>
-            )}
-
-            {/* Free Electives Section */}
-            {groupedSections.freeElectives && groupedSections.freeElectives.length > 0 && (
-              <div>
-                <Group gap="sm" mb="md">
-                  <ThemeIcon size={28} radius="md" variant="light" color="gray">
-                    <IconListCheck size={16} />
-                  </ThemeIcon>
-                  <Title order={3} size="h4">
-                    Free Electives
-                  </Title>
-                  <Badge variant="light" color="gray" size="sm">
-                    {new Set(groupedSections.freeElectives.map((s) => s.courseId)).size} courses
-                  </Badge>
-                </Group>
-                <Paper radius="lg" withBorder>
-                  {renderTable(groupedSections.freeElectives)}
                 </Paper>
               </div>
             )}
@@ -920,7 +967,9 @@ export default function ScheduleContent() {
                     No courses available
                   </Title>
                   <Text c="dimmed" size="sm">
-                    No courses for {decodeHtmlEntities(selectedSpec.name)} are offered in {getTermLabel(activeSemester)}.
+                    {searchQuery
+                      ? `No ${decodeHtmlEntities(selectedSpec.name)} courses match "${searchQuery}" in ${getTermLabel(activeSemester)}.`
+                      : `No courses for ${decodeHtmlEntities(selectedSpec.name)} are offered in ${getTermLabel(activeSemester)}.`}
                   </Text>
                 </Stack>
               </Paper>
@@ -928,13 +977,13 @@ export default function ScheduleContent() {
           </Stack>
         ) : (
           // Default ungrouped view
-          <Paper radius="lg" withBorder>
+          <Paper {...getScheduleTablePaperProps()}>
             {renderTable(filteredAndSortedSections)}
           </Paper>
         )}
 
         {/* Empty Search State */}
-        {!loading && sections.length > 0 && filteredAndSortedSections.length === 0 && (
+        {!loading && !selectedSpec && sections.length > 0 && displayedSections.length === 0 && (
           <Paper p="xl" radius="lg" withBorder ta="center" mt="xl">
             <Stack align="center" gap="md">
               <ThemeIcon size={60} radius="xl" variant="light" color="gray">

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { createContext, useContext, useEffect, useState, useRef } from 'react';
-import { getClient } from '@/lib/supabase/client';
+import { getClient, hasSupabaseBrowserConfig } from '@/lib/supabase/client';
 import { useRouter } from 'next/navigation';
 import { notifySuccess, notifyError } from '@/utils/notifications';
 import type { User, Session } from '@supabase/supabase-js';
@@ -61,7 +61,24 @@ export const AuthProvider = ({ children }: TContextProviderProps) => {
   routerRef.current = router;
 
   useEffect(() => {
-    const supabase = getClient();
+    if (!hasSupabaseBrowserConfig()) {
+      setSession(null);
+      setUser(null);
+      previousUserRef.current = null;
+      setLoading(false);
+      return;
+    }
+
+    let supabase: ReturnType<typeof getClient>;
+    try {
+      supabase = getClient();
+    } catch {
+      setSession(null);
+      setUser(null);
+      previousUserRef.current = null;
+      setLoading(false);
+      return;
+    }
 
     // Get initial session. If local auth state is corrupt/stale, fail closed
     // to anonymous and ask the server cleanup route to expire any leftover
@@ -136,7 +153,25 @@ export const AuthProvider = ({ children }: TContextProviderProps) => {
   const signInWithProvider = async (
     provider: 'google' | 'github'
   ) => {
-    const supabase = getClient();
+    if (!hasSupabaseBrowserConfig()) {
+      notifyError({
+        title: 'Sign in unavailable',
+        message: 'Authentication is not configured for this deployment.',
+      });
+      return;
+    }
+
+    let supabase: ReturnType<typeof getClient>;
+    try {
+      supabase = getClient();
+    } catch {
+      notifyError({
+        title: 'Sign in unavailable',
+        message: 'Authentication is not configured for this deployment.',
+      });
+      return;
+    }
+
     const { error } = await supabase.auth.signInWithOAuth({
       provider,
       options: {
@@ -153,7 +188,25 @@ export const AuthProvider = ({ children }: TContextProviderProps) => {
   };
 
   const signInWithEmailOtp = async (email: string): Promise<boolean> => {
-    const supabase = getClient();
+    if (!hasSupabaseBrowserConfig()) {
+      notifyError({
+        title: 'Sign in unavailable',
+        message: 'Authentication is not configured for this deployment.',
+      });
+      return false;
+    }
+
+    let supabase: ReturnType<typeof getClient>;
+    try {
+      supabase = getClient();
+    } catch {
+      notifyError({
+        title: 'Sign in unavailable',
+        message: 'Authentication is not configured for this deployment.',
+      });
+      return false;
+    }
+
     const { error } = await supabase.auth.signInWithOtp({ email });
 
     if (error) {
@@ -180,9 +233,17 @@ export const AuthProvider = ({ children }: TContextProviderProps) => {
   };
 
   const logout = async () => {
-    const supabase = getClient();
+    let supabase: ReturnType<typeof getClient> | null = null;
+    if (hasSupabaseBrowserConfig()) {
+      try {
+        supabase = getClient();
+      } catch {
+        // Auth is unavailable in this deployment; still clear local app state.
+      }
+    }
+
     try {
-      await supabase.auth.signOut();
+      await supabase?.auth.signOut();
     } finally {
       await fetch('/auth/logout', { method: 'POST' }).catch(() => {});
     }

--- a/src/context/context-providers.test.tsx
+++ b/src/context/context-providers.test.tsx
@@ -6,6 +6,19 @@ const signInWithOAuth = jest.fn();
 const signInWithOtp = jest.fn();
 const signOut = jest.fn();
 const getSession = jest.fn();
+const hasSupabaseBrowserConfig = jest.fn(() => true);
+const getClient = jest.fn(() => ({
+  auth: {
+    getSession,
+    onAuthStateChange: (callback: typeof authCallback) => {
+      authCallback = callback;
+      return { data: { subscription: { unsubscribe } } };
+    },
+    signInWithOAuth,
+    signInWithOtp,
+    signOut,
+  },
+}));
 let authCallback: ((event: string, session: any) => void) | undefined;
 const setters: jest.Mock[] = [];
 
@@ -19,18 +32,8 @@ jest.mock('@/utils/notifications', () => ({
 }));
 
 jest.mock('@/lib/supabase/client', () => ({
-  getClient: () => ({
-    auth: {
-      getSession,
-      onAuthStateChange: (callback: typeof authCallback) => {
-        authCallback = callback;
-        return { data: { subscription: { unsubscribe } } };
-      },
-      signInWithOAuth,
-      signInWithOtp,
-      signOut,
-    },
-  }),
+  getClient: (...args: unknown[]) => getClient(...args),
+  hasSupabaseBrowserConfig: (...args: unknown[]) => hasSupabaseBrowserConfig(...args),
 }));
 
 jest.mock('react', () => {
@@ -65,6 +68,19 @@ describe('context providers', () => {
     signInWithOAuth.mockResolvedValue({ error: null });
     signInWithOtp.mockResolvedValue({ error: null });
     signOut.mockResolvedValue(undefined);
+    hasSupabaseBrowserConfig.mockReturnValue(true);
+    getClient.mockImplementation(() => ({
+      auth: {
+        getSession,
+        onAuthStateChange: (callback: typeof authCallback) => {
+          authCallback = callback;
+          return { data: { subscription: { unsubscribe } } };
+        },
+        signInWithOAuth,
+        signInWithOtp,
+        signOut,
+      },
+    }));
     global.fetch = jest.fn(async () => ({ ok: true })) as any;
   });
 
@@ -152,5 +168,27 @@ describe('context providers', () => {
     await Promise.resolve();
     expect(global.fetch).toHaveBeenCalledWith('/auth/logout', { method: 'POST' });
     expect(unsubscribe).toHaveBeenCalled();
+  });
+
+  it('falls back to anonymous auth state when Supabase browser config is unavailable', async () => {
+    hasSupabaseBrowserConfig.mockReturnValue(false);
+
+    const { AuthProvider } = await import('@/context/AuthContext');
+    const element = AuthProvider({ children: null } as any) as any;
+
+    expect(element.props.value.user).toBeNull();
+    expect(element.props.value.session).toBeNull();
+    expect(setters.some((setter) => setter.mock.calls.some(([value]) => value === false))).toBe(true);
+
+    await expect(element.props.value.signInWithEmailOtp('student@example.com')).resolves.toBe(false);
+    await element.props.value.signInWithProvider('github');
+    await element.props.value.logout();
+
+    expect(notifyError).toHaveBeenCalledWith(expect.objectContaining({ title: 'Sign in unavailable' }));
+    expect(getClient).not.toHaveBeenCalled();
+    expect(signInWithOtp).not.toHaveBeenCalled();
+    expect(signInWithOAuth).not.toHaveBeenCalled();
+    expect(signOut).not.toHaveBeenCalled();
+    expect(global.fetch).toHaveBeenCalledWith('/auth/logout', { method: 'POST' });
   });
 });

--- a/src/lib/supabase/__tests__/client.test.ts
+++ b/src/lib/supabase/__tests__/client.test.ts
@@ -22,8 +22,9 @@ describe('createClient()', () => {
   });
 
   it('keeps browser auth cookies host-only on the default test host', async () => {
-    const { createClient } = await import('../client');
+    const { createClient, hasSupabaseBrowserConfig } = await import('../client');
 
+    expect(hasSupabaseBrowserConfig()).toBe(true);
     createClient();
 
     expect(mockCreateBrowserClient).toHaveBeenCalledWith(
@@ -32,12 +33,44 @@ describe('createClient()', () => {
       { cookieOptions: { domain: undefined } }
     );
   });
+
+  it('reports missing browser config before constructing Supabase client', async () => {
+    process.env = { ...originalEnv };
+    const { hasSupabaseBrowserConfig } = await import('../client');
+
+    expect(hasSupabaseBrowserConfig()).toBe(false);
+    expect(mockCreateBrowserClient).not.toHaveBeenCalled();
+  });
+
+  it('rejects serialized undefined browser config placeholders', async () => {
+    process.env = {
+      ...originalEnv,
+      NEXT_PUBLIC_SUPABASE_URL: 'undefined',
+      NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: 'undefined',
+    };
+    const { createClient, hasSupabaseBrowserConfig } = await import('../client');
+
+    expect(hasSupabaseBrowserConfig()).toBe(false);
+    expect(() => createClient()).toThrow('Supabase browser client is not configured');
+    expect(mockCreateBrowserClient).not.toHaveBeenCalled();
+  });
 });
 
 describe('getClient()', () => {
+  const originalEnv = process.env;
+
   beforeEach(() => {
     jest.resetModules();
     jest.clearAllMocks();
+    process.env = {
+      ...originalEnv,
+      NEXT_PUBLIC_SUPABASE_URL: 'https://example.supabase.co',
+      NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: 'publishable-key',
+    };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
   });
 
   it('memoizes the browser Supabase client', async () => {

--- a/src/lib/supabase/__tests__/proxy.test.ts
+++ b/src/lib/supabase/__tests__/proxy.test.ts
@@ -19,6 +19,8 @@ jest.mock('next/server', () => ({
   },
 }));
 
+const originalEnv = process.env;
+
 function makeMockRequest(
   cookies: Array<{ name: string; value: string }> = [],
   options: {
@@ -49,7 +51,25 @@ function makeMockRequest(
 describe('updateSession()', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    process.env = {
+      ...originalEnv,
+      NEXT_PUBLIC_SUPABASE_URL: 'https://example.supabase.co',
+      NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: 'publishable-key',
+    };
     mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it('skips Supabase session refresh when preview runtime env vars are missing', async () => {
+    process.env = { ...originalEnv };
+
+    await expect(updateSession(makeMockRequest())).resolves.toBeDefined();
+
+    expect(createServerClient).not.toHaveBeenCalled();
+    expect(mockGetUser).not.toHaveBeenCalled();
   });
 
   it('does NOT call getUser() when no session cookie is present', async () => {

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -14,10 +14,36 @@ export function getCookieDomain(hostname?: string): string | undefined {
   return undefined;
 }
 
+export function hasSupabaseBrowserConfig() {
+  return getSupabaseBrowserConfig() !== null;
+}
+
+function getSupabaseBrowserConfig() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const publishableKey = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY;
+
+  if (
+    !url ||
+    !publishableKey ||
+    url === 'undefined' ||
+    publishableKey === 'undefined' ||
+    !/^https?:\/\//.test(url)
+  ) {
+    return null;
+  }
+
+  return { publishableKey, url };
+}
+
 export function createClient() {
+  const config = getSupabaseBrowserConfig();
+  if (!config) {
+    throw new Error('Supabase browser client is not configured');
+  }
+
   return createBrowserClient<Database>(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
+    config.url,
+    config.publishableKey,
     { cookieOptions: { domain: getCookieDomain() } }
   );
 }

--- a/src/lib/supabase/proxy.ts
+++ b/src/lib/supabase/proxy.ts
@@ -39,14 +39,30 @@ function clearAuthTokenCookies(request: NextRequest, response: NextResponse) {
     });
 }
 
+function getSupabaseProxyConfig() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const publishableKey = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY;
+
+  if (!url || !publishableKey) {
+    return null;
+  }
+
+  return { publishableKey, url };
+}
+
 export async function updateSession(request: NextRequest) {
   let supabaseResponse = NextResponse.next({
     request,
   });
 
+  const supabaseConfig = getSupabaseProxyConfig();
+  if (!supabaseConfig) {
+    return supabaseResponse;
+  }
+
   const supabase = createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
+    supabaseConfig.url,
+    supabaseConfig.publishableKey,
     {
       cookies: {
         getAll() {


### PR DESCRIPTION
## Summary
- replace the schedule table rendering shell to avoid the row/header overlap shown on `/schedule`
- remove the hidden spacer row and header shadow hack that created the blank band below the schedule header
- align the schedule table light-theme accent with the existing GT palette: navy header, Tech Gold header rule, and adaptive Mantine row borders
- remove the sticky header offset from the shared course catalog table used on `/` and `/course`
- switch production table scroll containers to native overflow where the Mantine custom scroll wrapper can cause header/body painting artifacts
- keep the schedule specialization filter restricted to matching core and elective courses
- update displayed section counts and regression coverage for the schedule table/filter behavior
- prevent public pages from crashing when Vercel preview deployments do not have Supabase browser/proxy env vars

## Debug notes
- Vercel logs for the earlier preview showed `Your project's URL and Key are required to create a Supabase client!`
- Server/proxy HEAD checks were green, but local browser reproduction still failed because `AuthProvider` created the browser Supabase client on mount without public Supabase env vars
- The recurring blank schedule band came from an explicit `aria-hidden` grid row with `min-height: 72px`; clean production verification now shows no hidden rows and a `0px` gap between header and first course row
- Light-theme browser verification now renders the schedule header as GT navy (`rgb(0, 48, 87)`), the accent rule as Tech Gold (`rgb(179, 163, 105)`), and row borders as the light Mantine default border

## Validation
- `pnpm test:ci --runTestsByPath app/_components/CoursesTable.test.ts app/schedule/_components/ScheduleContent.test.ts app/schedule/ScheduleContent.integration.test.ts app/schedule/_lib/semesters.test.ts --runInBand`
- `pnpm test:ci --runTestsByPath app/schedule/_components/ScheduleContent.test.ts src/context/context-providers.test.tsx src/lib/supabase/__tests__/client.test.ts src/lib/supabase/__tests__/proxy.test.ts --runInBand`
- `pnpm test:ci --runTestsByPath app/schedule/_components/ScheduleContent.test.ts --runInBand`
- `pnpm exec eslint app/_components/CoursesTable.tsx app/_components/CoursesTable.test.ts app/availability/AvailabilityContent.tsx app/schedule/_components/ScheduleContent.tsx app/schedule/_components/ScheduleContent.test.ts`
- `pnpm exec eslint app/schedule/_components/ScheduleContent.tsx app/schedule/_components/ScheduleContent.test.ts src/context/AuthContext.tsx src/context/context-providers.test.tsx src/lib/supabase/client.ts src/lib/supabase/__tests__/client.test.ts src/lib/supabase/proxy.ts src/lib/supabase/__tests__/proxy.test.ts`
- `pnpm exec eslint app/schedule/_components/ScheduleContent.tsx app/schedule/_components/ScheduleContent.test.ts`
- `NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=dummy pnpm build`
- `pnpm build`
- production browser verification at `http://127.0.0.1:3011/schedule`: no runtime overlay, no hidden spacer rows, first schedule row starts at the header boundary (`gap: 0`)
- light-theme browser verification at `http://127.0.0.1:3012/schedule`: header/background/accent colors match GT brand tokens
- Vercel protected-preview checks via `vercel curl` returned 200 for `/`, `/schedule`, `/course`, and `/availability`; current deployment logs showed no 500 errors
