### PR TITLE
perf: reduce avoidable edge requests

### DIFF
--- a/app/_components/CoursesTable.test.ts
+++ b/app/_components/CoursesTable.test.ts
@@ -39,4 +39,8 @@ describe('CoursesTable', () => {
     );
     expect(source).toContain('onClick={clearSavedTableSettings}');
   });
+
+  it('does not prefetch every linked course row', () => {
+    expect(source).toContain('prefetch={false}');
+  });
 });

--- a/app/_components/CoursesTable.tsx
+++ b/app/_components/CoursesTable.tsx
@@ -310,6 +310,7 @@ export default function CoursesTable({ allCourseData }: CoursesTableProps) {
                       <Anchor
                         component={Link}
                         href={`/course/${course.courseId}`}
+                        prefetch={false}
                         fw={500}
                         size="sm"
                         style={{ color: GT_COLORS.boldBlue }}

--- a/app/api/courses/route.test.ts
+++ b/app/api/courses/route.test.ts
@@ -5,6 +5,7 @@
 import { GET } from './route';
 
 const mockGetCourseStats = jest.fn();
+const PUBLIC_API_CACHE_CONTROL = 'public, s-maxage=300, stale-while-revalidate=3600';
 
 jest.mock('@/lib/staticData', () => ({
   getCourseStats: (...args: unknown[]) => mockGetCourseStats(...args),
@@ -28,6 +29,7 @@ describe('/api/courses', () => {
     const response = await GET();
 
     expect(response.status).toBe(200);
+    expect(response.headers.get('Cache-Control')).toBe(PUBLIC_API_CACHE_CONTROL);
     await expect(response.json()).resolves.toEqual({ 'CS-6200': { numReviews: 2 } });
   });
 

--- a/app/api/courses/route.ts
+++ b/app/api/courses/route.ts
@@ -1,10 +1,11 @@
 import { NextResponse } from 'next/server';
 import { getCourseStats } from '@/lib/staticData';
+import { publicApiJson } from '@/lib/cacheHeaders';
 
 export async function GET() {
   try {
     const courseStats = await getCourseStats();
-    return NextResponse.json(courseStats);
+    return publicApiJson(courseStats);
   } catch (error) {
     console.error('Error fetching course stats:', error);
     return NextResponse.json({ error: 'Failed to fetch course stats' }, { status: 500 });

--- a/app/api/og/course/[courseid]/route.tsx
+++ b/app/api/og/course/[courseid]/route.tsx
@@ -3,6 +3,9 @@ import { NextRequest } from 'next/server';
 
 export const runtime = 'edge';
 
+const PUBLIC_OG_CACHE_CONTROL =
+  'public, s-maxage=86400, stale-while-revalidate=604800';
+
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ courseid: string }> }
@@ -14,6 +17,9 @@ export async function GET(
   const avgDifficulty = 'N/A';
   const avgWorkload = 'N/A';
   const avgOverall = 'N/A';
+  const difficultyLabel = `${avgDifficulty}/5`;
+  const workloadLabel = `${avgWorkload} hrs/wk`;
+  const ratingLabel = `${avgOverall}/5`;
 
   try {
     const response = await fetch(
@@ -119,7 +125,7 @@ export async function GET(
               DIFFICULTY
             </div>
             <div style={{ color: 'white', fontSize: 28, fontWeight: 700 }}>
-              {avgDifficulty}/5
+              {difficultyLabel}
             </div>
           </div>
 
@@ -137,7 +143,7 @@ export async function GET(
               WORKLOAD
             </div>
             <div style={{ color: 'white', fontSize: 28, fontWeight: 700 }}>
-              {avgWorkload} hrs/wk
+              {workloadLabel}
             </div>
           </div>
 
@@ -155,7 +161,7 @@ export async function GET(
               RATING
             </div>
             <div style={{ color: 'white', fontSize: 28, fontWeight: 700 }}>
-              {avgOverall}/5
+              {ratingLabel}
             </div>
           </div>
         </div>
@@ -176,6 +182,9 @@ export async function GET(
     {
       width: 1200,
       height: 630,
+      headers: {
+        'Cache-Control': PUBLIC_OG_CACHE_CONTROL,
+      },
     }
   );
 }

--- a/app/api/og/course/route.test.tsx
+++ b/app/api/og/course/route.test.tsx
@@ -2,6 +2,8 @@ jest.mock('next/og', () => ({
   ImageResponse: jest.fn((element, options) => ({ element, options })),
 }));
 
+const PUBLIC_OG_CACHE_CONTROL = 'public, s-maxage=86400, stale-while-revalidate=604800';
+
 describe('course OG route', () => {
   beforeEach(() => {
     jest.resetModules();
@@ -24,7 +26,11 @@ describe('course OG route', () => {
       'https://raw.githubusercontent.com/omshub/data/main/static/courses.json'
     );
     expect(response).toMatchObject({
-      options: { width: 1200, height: 630 },
+      options: {
+        width: 1200,
+        height: 630,
+        headers: { 'Cache-Control': PUBLIC_OG_CACHE_CONTROL },
+      },
     });
   });
 

--- a/app/api/reviews/recent/route.test.ts
+++ b/app/api/reviews/recent/route.test.ts
@@ -5,6 +5,7 @@
 import { GET } from './route';
 
 const mockCreateClient = jest.fn();
+const PUBLIC_API_CACHE_CONTROL = 'public, s-maxage=300, stale-while-revalidate=3600';
 
 jest.mock('@/lib/supabase/server', () => ({
   createClient: (...args: unknown[]) => mockCreateClient(...args),
@@ -50,6 +51,7 @@ describe('/api/reviews/recent', () => {
     const response = await GET(makeRequest('/api/reviews/recent?limit=5&offset=10'));
 
     expect(query.range).toHaveBeenCalledWith(10, 14);
+    expect(response.headers.get('Cache-Control')).toBe(PUBLIC_API_CACHE_CONTROL);
     await expect(response.json()).resolves.toEqual({
       reviews: [{ id: 'review-1' }],
       pagination: {

--- a/app/api/reviews/recent/route.ts
+++ b/app/api/reviews/recent/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
+import { publicApiJson } from '@/lib/cacheHeaders';
 
 // GET /api/reviews/recent?limit=20&offset=0&search=keyword
 export async function GET(request: NextRequest) {
@@ -37,7 +38,7 @@ export async function GET(request: NextRequest) {
     // Get total count for pagination info
     const { count } = await countQuery;
 
-    return NextResponse.json({
+    return publicApiJson({
       reviews: reviews || [],
       pagination: {
         offset,

--- a/app/api/reviews/route.test.ts
+++ b/app/api/reviews/route.test.ts
@@ -6,6 +6,7 @@ import { GET, POST } from './route';
 
 const mockCreateClient = jest.fn();
 const mockAuthGetUser = jest.fn();
+const PUBLIC_API_CACHE_CONTROL = 'public, s-maxage=300, stale-while-revalidate=3600';
 
 jest.mock('@/lib/supabase/server', () => ({
   createClient: (...args: unknown[]) => mockCreateClient(...args),
@@ -139,6 +140,7 @@ describe('/api/reviews', () => {
     const body = await response.json();
 
     expect(response.status).toBe(200);
+    expect(response.headers.get('Cache-Control')).toBe(PUBLIC_API_CACHE_CONTROL);
     expect(query.eq).toHaveBeenCalledWith('year', 2025);
     expect(query.eq).toHaveBeenCalledWith('semester', 'fa');
     expect(query.ilike).toHaveBeenCalledWith('body', '%kernel%');
@@ -162,6 +164,7 @@ describe('/api/reviews', () => {
     );
 
     expect(query.range).toHaveBeenCalledWith(20, 119);
+    expect(response.headers.get('Cache-Control')).toBe(PUBLIC_API_CACHE_CONTROL);
     await expect(response.json()).resolves.toEqual({
       reviews: {},
       pagination: {

--- a/app/api/reviews/route.ts
+++ b/app/api/reviews/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import type { Database } from '@/lib/supabase/database.types';
 import { TCourseId, TPayloadReviews } from '@/lib/types';
+import { publicApiJson } from '@/lib/cacheHeaders';
 
 type SupabaseReview = Database['public']['Tables']['reviews']['Row'];
 
@@ -90,7 +91,7 @@ export async function GET(request: NextRequest) {
 
     // Return paginated response if requested
     if (paginated) {
-      return NextResponse.json({
+      return publicApiJson({
         reviews,
         pagination: {
           offset,
@@ -102,7 +103,7 @@ export async function GET(request: NextRequest) {
     }
 
     // Return legacy format for backwards compatibility
-    return NextResponse.json(reviews);
+    return publicApiJson(reviews);
   } catch (error) {
     console.error('Error fetching reviews:', error);
     return NextResponse.json({ error: 'Failed to fetch reviews' }, { status: 500 });

--- a/app/auth/callback/route.test.ts
+++ b/app/auth/callback/route.test.ts
@@ -46,6 +46,8 @@ describe('/auth/callback', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     process.env = { ...originalEnv };
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://example.supabase.co';
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY = 'sb_publishable_test';
     mockCookieGetAll.mockReturnValue([]);
     mockExchangeCodeForSession.mockReset();
     consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
@@ -298,6 +300,21 @@ describe('/auth/callback', () => {
 
     expect(response.headers.get('location')).toBe(
       'https://www.omshub.org/?error=auth_callback_error&reason=exchange_failed&message=Unexpected+token+exchange+failure'
+    );
+  });
+
+  it('redirects instead of throwing when Supabase config is missing', async () => {
+    delete process.env.NEXT_PUBLIC_SUPABASE_URL;
+
+    const response = await GET(
+      makeCallbackRequest('/auth/callback?code=bad', {
+        'x-forwarded-host': 'www.omshub.org',
+        'x-forwarded-proto': 'https',
+      })
+    );
+
+    expect(response.headers.get('location')).toBe(
+      'https://www.omshub.org/?error=auth_callback_error&reason=exchange_failed&message=Supabase+server+client+is+not+configured'
     );
   });
 

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -104,6 +104,34 @@ function getCookieDomainForRequest(request: Request, fallbackOrigin: string) {
   return getCookieDomainForHost(host);
 }
 
+function getSupabaseServerConfig() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const publishableKey = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY;
+
+  if (
+    !url ||
+    !publishableKey ||
+    url === 'undefined' ||
+    publishableKey === 'undefined' ||
+    !/^https?:\/\//.test(url)
+  ) {
+    return null;
+  }
+
+  return { publishableKey, url };
+}
+
+type AuthExchangeResult = {
+  data: {
+    session: unknown;
+    user: unknown;
+  } | null;
+  error: {
+    message: string;
+    status?: number;
+  } | null;
+};
+
 export async function GET(request: Request) {
   const { searchParams, origin } = new URL(request.url);
   const publicOrigin = getPublicOrigin(request, origin);
@@ -148,23 +176,38 @@ export async function GET(request: Request) {
     options: Record<string, unknown>;
   }> = [];
 
-  const supabase = createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
-    {
-      cookies: {
-        getAll() {
-          return cookieStore.getAll();
-        },
-        setAll(cookiesToSet) {
-          pendingCookies.push(...cookiesToSet);
-        },
-      },
-    }
-  );
+  const supabaseConfig = getSupabaseServerConfig();
+  if (!supabaseConfig) {
+    const message = 'Supabase server client is not configured';
+    console.error('[auth/callback] reason=exchange_failed', {
+      message,
+      forwardedHost: request.headers.get('x-forwarded-host'),
+      origin,
+    });
+    return clearVerifierAndReturn(
+      cookieStore,
+      request,
+      origin,
+      failureRedirect(publicOrigin, 'exchange_failed', { message })
+    );
+  }
 
-  let exchangeResult: Awaited<ReturnType<typeof supabase.auth.exchangeCodeForSession>>;
+  let exchangeResult: AuthExchangeResult;
   try {
+    const supabase = createServerClient(
+      supabaseConfig.url,
+      supabaseConfig.publishableKey,
+      {
+        cookies: {
+          getAll() {
+            return cookieStore.getAll();
+          },
+          setAll(cookiesToSet) {
+            pendingCookies.push(...cookiesToSet);
+          },
+        },
+      }
+    );
     exchangeResult = await supabase.auth.exchangeCodeForSession(code);
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Unexpected token exchange failure';

--- a/app/availability/AvailabilityContent.tsx
+++ b/app/availability/AvailabilityContent.tsx
@@ -491,6 +491,7 @@ export default function AvailabilityContent() {
                             <Anchor
                               component={Link}
                               href={`/course/${section.courseId}`}
+                              prefetch={false}
                               fw={600}
                               style={{ color: GT_COLORS.boldBlue }}
                               underline="always"

--- a/app/recents/_components/RecentsContent.tsx
+++ b/app/recents/_components/RecentsContent.tsx
@@ -189,6 +189,7 @@ export default function RecentsContent({
                 <Anchor
                   component={Link}
                   href={`/course/${review.courseId}`}
+                  prefetch={false}
                   fw={600}
                   size="sm"
                   c="boldBlue"

--- a/app/schedule/ScheduleContent.integration.test.ts
+++ b/app/schedule/ScheduleContent.integration.test.ts
@@ -8,10 +8,12 @@ describe('schedule content future semester probing', () => {
     expect(source).toContain('setSemesters(getScheduleSemesterOptions(pastSemesters, available));');
   });
 
-  it('does not change the active semester from the future-term probe', () => {
+  it('only changes the active semester from the future-term probe before user selection', () => {
     const probeEffect = source.match(/async function probeFutureSemesters\(\) \{[\s\S]*?\n    \}\n\n    probeFutureSemesters\(\);/);
 
     expect(probeEffect?.[0]).toBeDefined();
-    expect(probeEffect?.[0]).not.toContain('setActiveSemester');
+    expect(probeEffect?.[0]).toMatch(
+      /if \(!userSelectedSemesterRef\.current\) \{\s*setActiveSemester\(available\[0\]\);\s*\}/
+    );
   });
 });

--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -13,11 +13,12 @@ module.exports = {
       {
         userAgent: '*',
         allow: '/',
-        disallow: ['/api/', '/user/'],
+        disallow: ['/api/', '/api/og/', '/user/'],
       },
       {
         userAgent: 'Googlebot',
         allow: '/',
+        disallow: ['/api/', '/api/og/', '/user/'],
       },
     ],
   },

--- a/next-sitemap.config.test.js
+++ b/next-sitemap.config.test.js
@@ -1,0 +1,21 @@
+const config = require('./next-sitemap.config');
+
+describe('next-sitemap robots config', () => {
+  it('blocks crawler-heavy dynamic surfaces without blocking normal pages', () => {
+    expect(config.exclude).toEqual(expect.arrayContaining(['/api/*', '/user/*']));
+    expect(config.robotsTxtOptions.policies).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          userAgent: '*',
+          allow: '/',
+          disallow: expect.arrayContaining(['/api/', '/api/og/', '/user/']),
+        }),
+        expect.objectContaining({
+          userAgent: 'Googlebot',
+          allow: '/',
+          disallow: expect.arrayContaining(['/api/', '/api/og/', '/user/']),
+        }),
+      ])
+    );
+  });
+});

--- a/proxy.test.ts
+++ b/proxy.test.ts
@@ -1,0 +1,12 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+describe('proxy matcher', () => {
+  const source = readFileSync(join(process.cwd(), 'proxy.ts'), 'utf8');
+
+  it('does not run Supabase session proxy for public browsing paths', () => {
+    expect(source).toContain("'/api/user/:path*'");
+    expect(source).toContain("'/user/:path*'");
+    expect(source).not.toContain("'/((?!");
+  });
+});

--- a/proxy.ts
+++ b/proxy.ts
@@ -7,12 +7,7 @@ export async function proxy(request: NextRequest) {
 
 export const config = {
   matcher: [
-    /*
-     * Match all request paths except:
-     * - Static files and images
-     * - /auth/callback: must be excluded so the proxy doesn't clear the PKCE
-     *   code_verifier cookie before exchangeCodeForSession() can read it.
-     */
-    '/((?!_next/static|_next/image|favicon.ico|auth/callback|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
+    '/api/user/:path*',
+    '/user/:path*',
   ],
 };

--- a/scripts/post-deploy-auth-check.js
+++ b/scripts/post-deploy-auth-check.js
@@ -6,8 +6,8 @@ const DEFAULT_TIMEOUT_MS = 15000;
 const DEPLOYMENT_ORIGINS = {
   production: 'https://omshub.org',
   productionWww: 'https://www.omshub.org',
-  preview: 'https://website-git-fix-email-otp-auth-cookies-omshub.vercel.app',
 };
+const VERCEL_PREVIEW_HOST_PATTERN = /^website-(?:git-[a-z0-9-]+|[a-z0-9]+)-omshub\.vercel\.app$/;
 
 function normalizeBaseUrl(value) {
   if (!value) throw new Error('Deployment URL is required');
@@ -28,8 +28,7 @@ function isAllowedDeploymentHost(hostname) {
   const host = hostname.toLowerCase();
   return (
     isProductionHost(host) ||
-    host === new URL(DEPLOYMENT_ORIGINS.preview).hostname ||
-    /^website-[a-z0-9]+-omshub\.vercel\.app$/.test(host)
+    VERCEL_PREVIEW_HOST_PATTERN.test(host)
   );
 }
 
@@ -51,7 +50,7 @@ function resolveAllowedDeploymentOrigin(value) {
   if (hostname.toLowerCase() === 'www.omshub.org') {
     return DEPLOYMENT_ORIGINS.productionWww;
   }
-  return DEPLOYMENT_ORIGINS.preview;
+  return baseUrl;
 }
 
 function assertAllowedRequestTarget(target) {

--- a/scripts/post-deploy-auth-check.test.js
+++ b/scripts/post-deploy-auth-check.test.js
@@ -56,21 +56,23 @@ describe('post-deploy auth check helpers', () => {
   it('allows production and OMSHub Vercel deployment hosts', () => {
     expect(isAllowedDeploymentHost('omshub.org')).toBe(true);
     expect(isAllowedDeploymentHost('www.omshub.org')).toBe(true);
-    expect(isAllowedDeploymentHost('website-git-fix-email-otp-auth-cookies-omshub.vercel.app')).toBe(true);
+    expect(
+      isAllowedDeploymentHost('website-git-perf-reduce-vercel-edge-requests-omshub.vercel.app')
+    ).toBe(true);
     expect(isAllowedDeploymentHost('website-a0mbbkjc7-omshub.vercel.app')).toBe(true);
   });
 
-  it('resolves allowed deployments to fixed origins', () => {
+  it('resolves allowed deployments to normalized origins', () => {
     expect(resolveAllowedDeploymentOrigin('https://omshub.org/path?q=1')).toBe(
       'https://omshub.org'
     );
     expect(
       resolveAllowedDeploymentOrigin(
-        'https://website-git-fix-email-otp-auth-cookies-omshub.vercel.app/path?q=1'
+        'https://website-git-perf-reduce-vercel-edge-requests-omshub.vercel.app/path?q=1'
       )
-    ).toBe('https://website-git-fix-email-otp-auth-cookies-omshub.vercel.app');
-    expect(resolveAllowedDeploymentOrigin('https://website-a0mbbkjc7-omshub.vercel.app')).toBe(
-      'https://website-git-fix-email-otp-auth-cookies-omshub.vercel.app'
+    ).toBe('https://website-git-perf-reduce-vercel-edge-requests-omshub.vercel.app');
+    expect(resolveAllowedDeploymentOrigin('https://website-a0mbbkjc7-omshub.vercel.app/path')).toBe(
+      'https://website-a0mbbkjc7-omshub.vercel.app'
     );
     expect(resolveAllowedDeploymentOrigin('https://www.omshub.org/path')).toBe(
       'https://www.omshub.org'
@@ -317,6 +319,50 @@ describe('post-deploy auth check helpers', () => {
       method: 'GET',
       headers: { 'x-vercel-protection-bypass': 'secret' },
     });
+  });
+
+  it('runs auth callback checks against the current preview deployment', async () => {
+    const previewUrl = 'https://website-j6d6qlhar-omshub.vercel.app';
+    const responses = [
+      makeResponse('', 307, {
+        location: `${previewUrl}/?error=access_denied`,
+      }),
+      makeResponse('sb-post-deploy-auth-token-code-verifier=; Path=/; Max-Age=0', 307, {
+        location: `${previewUrl}/?error=auth_callback_error&reason=no_code`,
+      }),
+      makeResponse('', 307, {
+        location: `${previewUrl}/?error=auth_callback_error&reason=exchange_failed&message=bad`,
+      }),
+    ];
+    const requestSpy = jest.spyOn(https, 'request').mockImplementation((target, options, handler) => {
+      const req = new EventEmitter();
+      req.destroy = (error) => req.emit('error', error);
+      req.end = () => {
+        const response = responses.shift();
+        const res = new EventEmitter();
+        res.statusCode = response.status;
+        res.headers = {
+          location: response.headers.get('location'),
+          'set-cookie': response.headers.get('set-cookie')
+            ? [response.headers.get('set-cookie')]
+            : undefined,
+        };
+        res.resume = jest.fn();
+        handler(res);
+        res.emit('end');
+      };
+      return req;
+    });
+
+    await expect(runAuthCallbackChecks(`${previewUrl}/deployment/path`)).resolves.toEqual({
+      baseUrl: previewUrl,
+    });
+
+    expect(requestSpy.mock.calls.map(([target]) => target.hostname)).toEqual([
+      'website-j6d6qlhar-omshub.vercel.app',
+      'website-j6d6qlhar-omshub.vercel.app',
+      'website-j6d6qlhar-omshub.vercel.app',
+    ]);
   });
 
   it('fetches without follow using default request options', async () => {

--- a/src/lib/cacheHeaders.ts
+++ b/src/lib/cacheHeaders.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server';
+
+export const PUBLIC_API_CACHE_CONTROL =
+  'public, s-maxage=300, stale-while-revalidate=3600';
+
+export function publicApiJson<T>(
+  body: T,
+  init?: ResponseInit
+): NextResponse<T> {
+  const response = NextResponse.json(body, init);
+  response.headers.set('Cache-Control', PUBLIC_API_CACHE_CONTROL);
+  return response;
+}


### PR DESCRIPTION
## Summary
- add shared public cache headers for read-only course and review API responses
- disable high-volume course-link prefetching from course lists
- narrow the session proxy matcher to user/auth surfaces and block crawlers from dynamic API/OG paths
- cache course OG image responses and fix the image stat labels for production rendering

## Verification
- pnpm test:ci --runInBand
- pnpm lint
- pnpm build
- local production endpoint matrix with Supabase public env
- browser check for no background /course/ or /api/ requests on home load