### PR TITLE
perf: reduce Supabase and Vercel traffic

### DIFF
--- a/app/api/courses/route.test.ts
+++ b/app/api/courses/route.test.ts
@@ -3,9 +3,9 @@
  */
 
 import { GET } from './route';
+import { PUBLIC_API_CACHE_CONTROL } from '@/lib/cacheHeaders';
 
 const mockGetCourseStats = jest.fn();
-const PUBLIC_API_CACHE_CONTROL = 'public, s-maxage=300, stale-while-revalidate=3600';
 
 jest.mock('@/lib/staticData', () => ({
   getCourseStats: (...args: unknown[]) => mockGetCourseStats(...args),

--- a/app/api/reviews/[reviewId]/route.test.ts
+++ b/app/api/reviews/[reviewId]/route.test.ts
@@ -3,177 +3,149 @@
  */
 
 import { DELETE, PUT } from './route';
+import { revalidatePath, revalidateTag } from 'next/cache';
 
-const mockCreateClient = jest.fn();
-const mockAuthGetUser = jest.fn();
-
-jest.mock('@/lib/supabase/server', () => ({
-  createClient: (...args: unknown[]) => mockCreateClient(...args),
+const mockGetAuthenticatedClaims = jest.fn();
+const mockFetchSingle = jest.fn();
+const mockFetchEq = jest.fn(() => ({ single: mockFetchSingle }));
+const mockSelect = jest.fn(() => ({ eq: mockFetchEq }));
+const mockDeleteEq = jest.fn();
+const mockDelete = jest.fn(() => ({ eq: mockDeleteEq }));
+const mockUpdateEq = jest.fn();
+const mockUpdate = jest.fn(() => ({ eq: mockUpdateEq }));
+const mockFrom = jest.fn(() => ({
+  select: mockSelect,
+  delete: mockDelete,
+  update: mockUpdate,
 }));
 
-function makeRequest(init?: RequestInit) {
-  return new Request('https://www.omshub.org/api/reviews/review-1', init);
-}
+jest.mock('@/lib/supabase/auth', () => ({
+  getAuthenticatedClaims: (...args: unknown[]) =>
+    mockGetAuthenticatedClaims(...args),
+}));
 
-function makeContext(reviewId = 'review-1') {
-  return { params: Promise.resolve({ reviewId }) };
-}
+jest.mock('@/lib/supabase/server', () => ({
+  createClient: jest.fn(async () => ({ from: mockFrom })),
+}));
 
-function makeQuery(result: unknown) {
-  const query: any = {
-    select: jest.fn(() => query),
-    eq: jest.fn(() => query),
-    single: jest.fn(() => query),
-    delete: jest.fn(() => query),
-    update: jest.fn(() => query),
-    then: (resolve: (value: unknown) => unknown) => Promise.resolve(resolve(result)),
-  };
-  return query;
-}
+jest.mock('@/lib/supabase/publicReviews', () => ({
+  courseReviewsCacheTag: (courseId: string) => `reviews:course:${courseId}`,
+  RECENT_REVIEWS_CACHE_TAG: 'reviews:recent',
+}));
+
+jest.mock('next/cache', () => ({
+  revalidatePath: jest.fn(),
+  revalidateTag: jest.fn(),
+}));
+
+const context = { params: Promise.resolve({ reviewId: 'review-1' }) };
+const deleteRequest = new Request(
+  'https://www.omshub.org/api/reviews/review-1',
+  { method: 'DELETE' }
+) as any;
+const updateRequest = () =>
+  new Request('https://www.omshub.org/api/reviews/review-1', {
+    method: 'PUT',
+    body: JSON.stringify({
+      body: 'Updated',
+      workload: 8,
+      difficulty: 2,
+      overall: 4,
+    }),
+  }) as any;
 
 describe('/api/reviews/[reviewId]', () => {
   let consoleErrorSpy: jest.SpyInstance;
-  let queries: any[];
 
   beforeEach(() => {
     jest.clearAllMocks();
     consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-    mockAuthGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null });
-    queries = [];
-    mockCreateClient.mockResolvedValue({
-      auth: { getUser: mockAuthGetUser },
-      from: jest.fn(() => queries.shift()),
+    mockGetAuthenticatedClaims.mockResolvedValue({ userId: 'user-1' });
+    mockFetchSingle.mockResolvedValue({
+      data: { reviewer_id: 'user-1', course_id: 'CS-6200' },
+      error: null,
     });
+    mockDeleteEq.mockResolvedValue({ error: null });
+    mockUpdateEq.mockResolvedValue({ error: null });
   });
 
-  afterEach(() => {
-    consoleErrorSpy.mockRestore();
-  });
+  afterEach(() => consoleErrorSpy.mockRestore());
 
-  it('requires authentication before deleting', async () => {
-    mockAuthGetUser.mockResolvedValueOnce({ data: { user: null }, error: null });
-
-    const response = await DELETE(makeRequest(), makeContext());
-
+  it.each([
+    ['delete', () => DELETE(deleteRequest, context)],
+    ['update', () => PUT(updateRequest(), context)],
+  ])('requires verified claims before %s', async (_name, run) => {
+    mockGetAuthenticatedClaims.mockResolvedValueOnce(null);
+    const response = await run();
     expect(response.status).toBe(401);
+    expect(mockSelect).not.toHaveBeenCalled();
   });
 
-  it('returns 404 when deleting a missing review', async () => {
-    queries.push(makeQuery({ data: null, error: new Error('not found') }));
-
-    const response = await DELETE(makeRequest(), makeContext());
-
+  it.each([
+    ['delete', () => DELETE(deleteRequest, context)],
+    ['update', () => PUT(updateRequest(), context)],
+  ])('returns 404 when the review is missing before %s', async (_name, run) => {
+    mockFetchSingle.mockResolvedValueOnce({
+      data: null,
+      error: { message: 'missing' },
+    });
+    const response = await run();
     expect(response.status).toBe(404);
   });
 
-  it('forbids deleting another user review', async () => {
-    queries.push(makeQuery({ data: { reviewer_id: 'user-2' }, error: null }));
-
-    const response = await DELETE(makeRequest(), makeContext());
-
+  it.each([
+    ['delete', () => DELETE(deleteRequest, context)],
+    ['update', () => PUT(updateRequest(), context)],
+  ])('forbids %s for a different owner', async (_name, run) => {
+    mockFetchSingle.mockResolvedValueOnce({
+      data: { reviewer_id: 'user-2', course_id: 'CS-6200' },
+      error: null,
+    });
+    const response = await run();
     expect(response.status).toBe(403);
   });
 
-  it('deletes the authenticated user review', async () => {
-    const fetchQuery = makeQuery({ data: { reviewer_id: 'user-1' }, error: null });
-    const deleteQuery = makeQuery({ error: null });
-    queries.push(fetchQuery, deleteQuery);
-
-    const response = await DELETE(makeRequest(), makeContext());
-
+  it('deletes an owned review and invalidates caches', async () => {
+    const response = await DELETE(deleteRequest, context);
     expect(response.status).toBe(200);
-    expect(deleteQuery.delete).toHaveBeenCalled();
-    await expect(response.json()).resolves.toEqual({ success: true });
-  });
-
-  it('returns a 500 when delete fails', async () => {
-    queries.push(
-      makeQuery({ data: { reviewer_id: 'user-1' }, error: null }),
-      makeQuery({ error: new Error('delete failed') })
+    expect(mockDeleteEq).toHaveBeenCalledWith('id', 'review-1');
+    expect(revalidateTag).toHaveBeenCalledWith(
+      'reviews:course:CS-6200',
+      'max'
     );
-
-    const response = await DELETE(makeRequest(), makeContext());
-
-    expect(response.status).toBe(500);
-    await expect(response.json()).resolves.toEqual({ error: 'Failed to delete review' });
+    expect(revalidateTag).toHaveBeenCalledWith('reviews:recent', 'max');
+    expect(revalidatePath).toHaveBeenCalledWith('/course/CS-6200');
   });
 
-  it('returns a 500 when delete throws', async () => {
-    mockCreateClient.mockRejectedValueOnce(new Error('client failed'));
-
-    const response = await DELETE(makeRequest(), makeContext());
-
-    expect(response.status).toBe(500);
-    await expect(response.json()).resolves.toEqual({ error: 'Internal server error' });
-  });
-
-  it('requires authentication before updating', async () => {
-    mockAuthGetUser.mockResolvedValueOnce({ data: { user: null }, error: null });
-
-    const response = await PUT(makeRequest({ method: 'PUT', body: '{}' }), makeContext());
-
-    expect(response.status).toBe(401);
-  });
-
-  it('returns 404 when updating a missing review', async () => {
-    queries.push(makeQuery({ data: null, error: new Error('not found') }));
-
-    const response = await PUT(makeRequest({ method: 'PUT', body: '{}' }), makeContext());
-
-    expect(response.status).toBe(404);
-  });
-
-  it('forbids updating another user review', async () => {
-    queries.push(makeQuery({ data: { reviewer_id: 'user-2' }, error: null }));
-
-    const response = await PUT(makeRequest({ method: 'PUT', body: '{}' }), makeContext());
-
-    expect(response.status).toBe(403);
-  });
-
-  it('updates the authenticated user review', async () => {
-    const updateQuery = makeQuery({ data: { id: 'review-1', body: 'updated' }, error: null });
-    queries.push(makeQuery({ data: { reviewer_id: 'user-1' }, error: null }), updateQuery);
-
-    const response = await PUT(
-      makeRequest({
-        method: 'PUT',
-        body: JSON.stringify({ body: 'updated', workload: 12, difficulty: 4, overall: 5 }),
-      }),
-      makeContext()
-    );
-
+  it('updates an owned review without returning the full row', async () => {
+    const response = await PUT(updateRequest(), context);
     expect(response.status).toBe(200);
-    expect(updateQuery.update).toHaveBeenCalledWith(
+    expect(mockUpdate).toHaveBeenCalledWith(
       expect.objectContaining({
-        body: 'updated',
-        workload: 12,
-        difficulty: 4,
-        overall: 5,
+        body: 'Updated',
+        workload: 8,
+        difficulty: 2,
+        overall: 4,
         modified_at: expect.any(String),
       })
     );
-    await expect(response.json()).resolves.toEqual({
-      review: { id: 'review-1', body: 'updated' },
+    expect(mockUpdateEq).toHaveBeenCalledWith('id', 'review-1');
+    await expect(response.json()).resolves.toEqual({ success: true });
+  });
+
+  it('returns 500 when deletion fails', async () => {
+    mockDeleteEq.mockResolvedValueOnce({
+      error: { message: 'delete failed' },
     });
+    const response = await DELETE(deleteRequest, context);
+    expect(response.status).toBe(500);
   });
 
-  it('returns a 500 when update fails', async () => {
-    queries.push(
-      makeQuery({ data: { reviewer_id: 'user-1' }, error: null }),
-      makeQuery({ data: null, error: new Error('update failed') })
-    );
-
-    const response = await PUT(makeRequest({ method: 'PUT', body: '{}' }), makeContext());
-
+  it('returns 500 when update fails', async () => {
+    mockUpdateEq.mockResolvedValueOnce({
+      error: { message: 'update failed' },
+    });
+    const response = await PUT(updateRequest(), context);
     expect(response.status).toBe(500);
-    await expect(response.json()).resolves.toEqual({ error: 'Failed to update review' });
-  });
-
-  it('returns a 500 when update body parsing throws', async () => {
-    const response = await PUT(makeRequest({ method: 'PUT', body: '{' }), makeContext());
-
-    expect(response.status).toBe(500);
-    await expect(response.json()).resolves.toEqual({ error: 'Internal server error' });
   });
 });

--- a/app/api/reviews/[reviewId]/route.ts
+++ b/app/api/reviews/[reviewId]/route.ts
@@ -2,6 +2,19 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
+import { getAuthenticatedClaims } from '@/lib/supabase/auth';
+import { revalidatePath, revalidateTag } from 'next/cache';
+import {
+  courseReviewsCacheTag,
+  RECENT_REVIEWS_CACHE_TAG,
+} from '@/lib/supabase/publicReviews';
+
+function invalidateReviewCaches(courseId: string) {
+  revalidateTag(courseReviewsCacheTag(courseId), 'max');
+  revalidateTag(RECENT_REVIEWS_CACHE_TAG, 'max');
+  revalidatePath(`/course/${courseId}`);
+  revalidatePath('/recents');
+}
 
 // DELETE /api/reviews/[reviewId]
 export async function DELETE(
@@ -12,16 +25,15 @@ export async function DELETE(
     const { reviewId } = await context.params;
     const supabase = await createClient();
 
-    // Get the current user
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
-    if (authError || !user) {
+    const auth = await getAuthenticatedClaims(supabase);
+    if (!auth) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
     // Check if the review belongs to the user
     const { data: review, error: fetchError } = await supabase
       .from('reviews')
-      .select('reviewer_id')
+      .select('reviewer_id, course_id')
       .eq('id', reviewId)
       .single();
 
@@ -29,7 +41,7 @@ export async function DELETE(
       return NextResponse.json({ error: 'Review not found' }, { status: 404 });
     }
 
-    if (review.reviewer_id !== user.id) {
+    if (review.reviewer_id !== auth.userId) {
       return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
     }
 
@@ -44,6 +56,7 @@ export async function DELETE(
       return NextResponse.json({ error: 'Failed to delete review' }, { status: 500 });
     }
 
+    invalidateReviewCaches(review.course_id);
     return NextResponse.json({ success: true });
   } catch (error) {
     console.error('Error in DELETE /api/reviews/[reviewId]:', error);
@@ -61,16 +74,15 @@ export async function PUT(
     const body = await request.json();
     const supabase = await createClient();
 
-    // Get the current user
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
-    if (authError || !user) {
+    const auth = await getAuthenticatedClaims(supabase);
+    if (!auth) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
     // Check if the review belongs to the user
     const { data: existingReview, error: fetchError } = await supabase
       .from('reviews')
-      .select('reviewer_id')
+      .select('reviewer_id, course_id')
       .eq('id', reviewId)
       .single();
 
@@ -78,12 +90,12 @@ export async function PUT(
       return NextResponse.json({ error: 'Review not found' }, { status: 404 });
     }
 
-    if (existingReview.reviewer_id !== user.id) {
+    if (existingReview.reviewer_id !== auth.userId) {
       return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
     }
 
     // Update the review
-    const { data: review, error: updateError } = await supabase
+    const { error: updateError } = await supabase
       .from('reviews')
       .update({
         body: body.body,
@@ -92,16 +104,15 @@ export async function PUT(
         overall: body.overall,
         modified_at: new Date().toISOString(),
       })
-      .eq('id', reviewId)
-      .select()
-      .single();
+      .eq('id', reviewId);
 
     if (updateError) {
       console.error('Error updating review:', updateError);
       return NextResponse.json({ error: 'Failed to update review' }, { status: 500 });
     }
 
-    return NextResponse.json({ review });
+    invalidateReviewCaches(existingReview.course_id);
+    return NextResponse.json({ success: true });
   } catch (error) {
     console.error('Error in PUT /api/reviews/[reviewId]:', error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });

--- a/app/api/reviews/recent/route.test.ts
+++ b/app/api/reviews/recent/route.test.ts
@@ -3,117 +3,77 @@
  */
 
 import { GET } from './route';
+import { PUBLIC_API_CACHE_CONTROL } from '@/lib/cacheHeaders';
 
-const mockCreateClient = jest.fn();
-const PUBLIC_API_CACHE_CONTROL = 'public, s-maxage=300, stale-while-revalidate=3600';
+const mockGetPublicReviewsPage = jest.fn();
 
-jest.mock('@/lib/supabase/server', () => ({
-  createClient: (...args: unknown[]) => mockCreateClient(...args),
+jest.mock('@/lib/supabase/publicReviews', () => ({
+  getPublicReviewsPage: (...args: unknown[]) => mockGetPublicReviewsPage(...args),
+  MAX_PUBLIC_REVIEW_LIMIT: 50,
+  MAX_PUBLIC_REVIEW_OFFSET: 5000,
+  MAX_PUBLIC_REVIEW_SEARCH_LENGTH: 100,
 }));
 
-function makeRequest(path: string) {
-  return new Request(`https://www.omshub.org${path}`);
-}
-
-function makeQuery(result: unknown) {
-  const query: any = {
-    select: jest.fn(() => query),
-    order: jest.fn(() => query),
-    ilike: jest.fn(() => query),
-    range: jest.fn(() => Promise.resolve(result)),
-    then: (resolve: (value: unknown) => unknown) => Promise.resolve(resolve(result)),
-  };
-  return query;
-}
+const makeRequest = (path: string) =>
+  new Request(`https://www.omshub.org${path}`) as any;
 
 describe('/api/reviews/recent', () => {
   let consoleErrorSpy: jest.SpyInstance;
-  let query: any;
-  let countQuery: any;
 
   beforeEach(() => {
     jest.clearAllMocks();
     consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-    query = makeQuery({ data: [{ id: 'review-1' }], error: null });
-    countQuery = makeQuery({ count: 20 });
-    mockCreateClient.mockResolvedValue({
-      from: jest.fn()
-        .mockReturnValueOnce(query)
-        .mockReturnValueOnce(countQuery),
+    mockGetPublicReviewsPage.mockResolvedValue({
+      reviews: [{ id: 'review-1' }],
+      hasMore: true,
     });
   });
 
-  afterEach(() => {
-    consoleErrorSpy.mockRestore();
-  });
+  afterEach(() => consoleErrorSpy.mockRestore());
 
-  it('returns recent reviews with pagination', async () => {
-    const response = await GET(makeRequest('/api/reviews/recent?limit=5&offset=10'));
+  it('forwards bounded pagination and search to the cached reader', async () => {
+    const response = await GET(
+      makeRequest('/api/reviews/recent?limit=5&offset=10&search=kernel')
+    );
 
-    expect(query.range).toHaveBeenCalledWith(10, 14);
+    expect(mockGetPublicReviewsPage).toHaveBeenCalledWith({
+      search: 'kernel',
+      limit: 5,
+      offset: 10,
+    });
     expect(response.headers.get('Cache-Control')).toBe(PUBLIC_API_CACHE_CONTROL);
     await expect(response.json()).resolves.toEqual({
       reviews: [{ id: 'review-1' }],
-      pagination: {
-        offset: 10,
-        limit: 5,
-        total: 20,
-        hasMore: true,
-      },
+      pagination: { offset: 10, limit: 5, hasMore: true },
     });
   });
 
-  it('filters recent reviews by search and caps limit', async () => {
-    const response = await GET(makeRequest('/api/reviews/recent?limit=999&search=kernel'));
-
-    expect(query.ilike).toHaveBeenCalledWith('body', '%kernel%');
-    expect(countQuery.ilike).toHaveBeenCalledWith('body', '%kernel%');
-    expect(query.range).toHaveBeenCalledWith(0, 99);
-    expect(response.status).toBe(200);
+  it.each([
+    '/api/reviews/recent?limit=0',
+    '/api/reviews/recent?limit=51',
+    '/api/reviews/recent?offset=-1',
+    '/api/reviews/recent?offset=5001',
+    '/api/reviews/recent?limit=not-a-number',
+  ])('rejects invalid pagination: %s', async (path) => {
+    const response = await GET(makeRequest(path));
+    expect(response.status).toBe(400);
+    expect(response.headers.get('Cache-Control')).toBe('private, no-store');
+    expect(mockGetPublicReviewsPage).not.toHaveBeenCalled();
   });
 
-  it('returns empty arrays and zero count defaults', async () => {
-    query = makeQuery({ data: null, error: null });
-    countQuery = makeQuery({ count: null });
-    mockCreateClient.mockResolvedValue({
-      from: jest.fn()
-        .mockReturnValueOnce(query)
-        .mockReturnValueOnce(countQuery),
-    });
+  it('rejects one-character searches', async () => {
+    const response = await GET(makeRequest('/api/reviews/recent?search=x'));
+    expect(response.status).toBe(400);
+    expect(mockGetPublicReviewsPage).not.toHaveBeenCalled();
+  });
 
+  it('returns an uncached 503 when the cached reader fails', async () => {
+    mockGetPublicReviewsPage.mockRejectedValueOnce(new Error('restricted'));
     const response = await GET(makeRequest('/api/reviews/recent'));
-
+    expect(response.status).toBe(503);
+    expect(response.headers.get('Cache-Control')).toBe('private, no-store');
     await expect(response.json()).resolves.toEqual({
-      reviews: [],
-      pagination: {
-        offset: 0,
-        limit: 20,
-        total: 0,
-        hasMore: false,
-      },
+      error: 'Failed to fetch reviews',
     });
-  });
-
-  it('returns a 500 when recent review lookup fails', async () => {
-    query = makeQuery({ data: null, error: new Error('select failed') });
-    mockCreateClient.mockResolvedValue({
-      from: jest.fn()
-        .mockReturnValueOnce(query)
-        .mockReturnValueOnce(countQuery),
-    });
-
-    const response = await GET(makeRequest('/api/reviews/recent'));
-
-    expect(response.status).toBe(500);
-    await expect(response.json()).resolves.toEqual({ error: 'Failed to fetch reviews' });
-  });
-
-  it('returns a 500 when the handler throws', async () => {
-    mockCreateClient.mockRejectedValueOnce(new Error('client failed'));
-
-    const response = await GET(makeRequest('/api/reviews/recent'));
-
-    expect(response.status).toBe(500);
-    await expect(response.json()).resolves.toEqual({ error: 'Internal server error' });
   });
 });

--- a/app/api/reviews/recent/route.ts
+++ b/app/api/reviews/recent/route.ts
@@ -1,54 +1,62 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@/lib/supabase/server';
-import { publicApiJson } from '@/lib/cacheHeaders';
+import { NextRequest } from 'next/server';
+import { publicApiJson, uncachedApiJson } from '@/lib/cacheHeaders';
+import {
+  getPublicReviewsPage,
+  MAX_PUBLIC_REVIEW_LIMIT,
+  MAX_PUBLIC_REVIEW_OFFSET,
+  MAX_PUBLIC_REVIEW_SEARCH_LENGTH,
+} from '@/lib/supabase/publicReviews';
+
+function parseInteger(value: string | null, fallback: number) {
+  if (value === null) return fallback;
+  const parsed = Number(value);
+  return Number.isInteger(parsed) ? parsed : null;
+}
 
 // GET /api/reviews/recent?limit=20&offset=0&search=keyword
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
-  const limit = Math.min(parseInt(searchParams.get('limit') || '20', 10), 100);
-  const offset = parseInt(searchParams.get('offset') || '0', 10);
+  const limit = parseInteger(searchParams.get('limit'), 20);
+  const offset = parseInteger(searchParams.get('offset'), 0);
   const search = searchParams.get('search')?.trim() || '';
 
+  if (
+    limit === null ||
+    limit < 1 ||
+    limit > MAX_PUBLIC_REVIEW_LIMIT ||
+    offset === null ||
+    offset < 0 ||
+    offset > MAX_PUBLIC_REVIEW_OFFSET
+  ) {
+    return uncachedApiJson({ error: 'Invalid pagination parameters' }, { status: 400 });
+  }
+  if (
+    search &&
+    (search.length < 2 || search.length > MAX_PUBLIC_REVIEW_SEARCH_LENGTH)
+  ) {
+    return uncachedApiJson(
+      { error: 'Search must be between 2 and 100 characters' },
+      { status: 400 }
+    );
+  }
+
   try {
-    const supabase = await createClient();
-
-    // Build query with optional search
-    let query = supabase
-      .from('reviews')
-      .select('*')
-      .order('created_at', { ascending: false });
-
-    let countQuery = supabase
-      .from('reviews')
-      .select('*', { count: 'exact', head: true });
-
-    // Add search filter if provided
-    if (search) {
-      query = query.ilike('body', `%${search}%`);
-      countQuery = countQuery.ilike('body', `%${search}%`);
-    }
-
-    const { data: reviews, error } = await query.range(offset, offset + limit - 1);
-
-    if (error) {
-      console.error('Error fetching recent reviews:', error);
-      return NextResponse.json({ error: 'Failed to fetch reviews' }, { status: 500 });
-    }
-
-    // Get total count for pagination info
-    const { count } = await countQuery;
+    const reviewPage = await getPublicReviewsPage({
+      search: search || undefined,
+      limit,
+      offset,
+    });
 
     return publicApiJson({
-      reviews: reviews || [],
+      reviews: reviewPage.reviews,
       pagination: {
         offset,
         limit,
-        total: count || 0,
-        hasMore: (offset + limit) < (count || 0),
+        hasMore: reviewPage.hasMore,
       },
     });
   } catch (error) {
     console.error('Error in GET /api/reviews/recent:', error);
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+    return uncachedApiJson({ error: 'Failed to fetch reviews' }, { status: 503 });
   }
 }

--- a/app/api/reviews/route.test.ts
+++ b/app/api/reviews/route.test.ts
@@ -3,300 +3,190 @@
  */
 
 import { GET, POST } from './route';
+import { PUBLIC_API_CACHE_CONTROL } from '@/lib/cacheHeaders';
+import { revalidatePath, revalidateTag } from 'next/cache';
 
-const mockCreateClient = jest.fn();
-const mockAuthGetUser = jest.fn();
-const PUBLIC_API_CACHE_CONTROL = 'public, s-maxage=300, stale-while-revalidate=3600';
+const mockGetPublicReviewsPage = jest.fn();
+const mockGetAuthenticatedClaims = jest.fn();
+const mockInsert = jest.fn();
+const mockFrom = jest.fn(() => ({ insert: mockInsert }));
 
-jest.mock('@/lib/supabase/server', () => ({
-  createClient: (...args: unknown[]) => mockCreateClient(...args),
+jest.mock('@/lib/supabase/publicReviews', () => ({
+  courseReviewsCacheTag: (courseId: string) => `reviews:course:${courseId}`,
+  getPublicReviewsPage: (...args: unknown[]) => mockGetPublicReviewsPage(...args),
+  MAX_PUBLIC_REVIEW_LIMIT: 50,
+  MAX_PUBLIC_REVIEW_OFFSET: 5000,
+  MAX_PUBLIC_REVIEW_SEARCH_LENGTH: 100,
+  RECENT_REVIEWS_CACHE_TAG: 'reviews:recent',
 }));
 
-function makeRequest(path: string, init?: RequestInit) {
-  return new Request(`https://www.omshub.org${path}`, init);
-}
+jest.mock('@/lib/supabase/auth', () => ({
+  getAuthenticatedClaims: (...args: unknown[]) =>
+    mockGetAuthenticatedClaims(...args),
+}));
 
-function makeQuery(result: unknown) {
-  const query: any = {
-    select: jest.fn(() => query),
-    eq: jest.fn(() => query),
-    order: jest.fn(() => query),
-    ilike: jest.fn(() => query),
-    range: jest.fn(() => query),
-    insert: jest.fn(() => query),
-    single: jest.fn(() => query),
-    then: (resolve: (value: unknown) => unknown) => Promise.resolve(resolve(result)),
-  };
-  return query;
-}
+jest.mock('@/lib/supabase/server', () => ({
+  createClient: jest.fn(async () => ({ from: mockFrom })),
+}));
+
+jest.mock('next/cache', () => ({
+  revalidatePath: jest.fn(),
+  revalidateTag: jest.fn(),
+}));
+
+const publicReview = {
+  id: 'review-1',
+  course_id: 'CS-6200',
+  reviewer_id: 'user-1',
+  year: 2025,
+  semester: 'fa',
+  body: 'Great course',
+  workload: 10,
+  difficulty: 3,
+  overall: 5,
+  is_legacy: false,
+  is_gt_verified: true,
+  upvotes: 2,
+  downvotes: 0,
+  created_at: '2025-08-01T00:00:00.000Z',
+  modified_at: null,
+};
+
+const makeRequest = (path: string, init?: RequestInit) =>
+  new Request(`https://www.omshub.org${path}`, init) as any;
 
 describe('/api/reviews', () => {
   let consoleErrorSpy: jest.SpyInstance;
-  let query: any;
 
   beforeEach(() => {
     jest.clearAllMocks();
     consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-    query = makeQuery({ data: [], error: null, count: 0 });
-    mockAuthGetUser.mockResolvedValue({
-      data: { user: { id: 'user-1', email: 'student@gatech.edu' } },
-      error: null,
+    mockGetPublicReviewsPage.mockResolvedValue({
+      reviews: [publicReview],
+      hasMore: false,
     });
-    mockCreateClient.mockResolvedValue({
-      auth: { getUser: mockAuthGetUser },
-      from: jest.fn(() => query),
+    mockGetAuthenticatedClaims.mockResolvedValue({
+      userId: 'user-1',
+      email: 'student@gatech.edu',
     });
+    mockInsert.mockResolvedValue({ error: null });
   });
 
-  afterEach(() => {
-    consoleErrorSpy.mockRestore();
-  });
+  afterEach(() => consoleErrorSpy.mockRestore());
 
-  it('requires courseId', async () => {
+  it('requires a valid courseId', async () => {
     const response = await GET(makeRequest('/api/reviews'));
-
     expect(response.status).toBe(400);
-    await expect(response.json()).resolves.toEqual({ error: 'courseId is required' });
+    expect(response.headers.get('Cache-Control')).toBe('private, no-store');
   });
 
-  it('returns filtered legacy review payloads', async () => {
-    query = makeQuery({
-      data: [
-        {
-          id: 'review-1',
-          course_id: 'CS-6200',
-          year: 2025,
-          semester: 'fa',
-          is_legacy: false,
-          reviewer_id: null,
-          is_gt_verified: true,
-          created_at: '2025-08-01T00:00:00.000Z',
-          modified_at: '2025-08-02T00:00:00.000Z',
-          body: null,
-          upvotes: 0,
-          downvotes: 0,
-          workload: null,
-          difficulty: null,
-          overall: null,
-          staff_support: null,
-          is_recommended: null,
-          is_good_first_course: null,
-          is_pairable: null,
-          has_group_projects: null,
-          has_writing_assignments: null,
-          has_exams_quizzes: null,
-          has_mandatory_readings: null,
-          has_programming_assignments: null,
-          has_provided_dev_env: null,
-          programming_languages: ['c'],
-          preparation: null,
-          oms_courses_taken: 0,
-          has_relevant_work_experience: null,
-          experience_level: null,
-          grade: null,
-        },
-        {
-          id: 'review-2',
-          course_id: 'CS-6200',
-          year: 2025,
-          semester: 'fa',
-          is_legacy: false,
-          reviewer_id: 'user-1',
-          is_gt_verified: true,
-          created_at: '2025-08-01T00:00:00.000Z',
-          modified_at: null,
-          body: 'body',
-          upvotes: 0,
-          downvotes: 0,
-          workload: 1,
-          difficulty: 2,
-          overall: 3,
-          staff_support: null,
-          is_recommended: null,
-          is_good_first_course: null,
-          is_pairable: null,
-          has_group_projects: null,
-          has_writing_assignments: null,
-          has_exams_quizzes: null,
-          has_mandatory_readings: null,
-          has_programming_assignments: null,
-          has_provided_dev_env: null,
-          programming_languages: null,
-          preparation: null,
-          oms_courses_taken: 0,
-          has_relevant_work_experience: null,
-          experience_level: null,
-          grade: null,
-        },
-      ],
-      error: null,
-      count: 1,
-    });
-    mockCreateClient.mockResolvedValue({ from: jest.fn(() => query) });
-
+  it('returns cached paginated reviews without exact counts', async () => {
     const response = await GET(
-      makeRequest('/api/reviews?courseId=CS-6200&year=2025&semester=fa&search=kernel')
-    );
-    const body = await response.json();
-
-    expect(response.status).toBe(200);
-    expect(response.headers.get('Cache-Control')).toBe(PUBLIC_API_CACHE_CONTROL);
-    expect(query.eq).toHaveBeenCalledWith('year', 2025);
-    expect(query.eq).toHaveBeenCalledWith('semester', 'fa');
-    expect(query.ilike).toHaveBeenCalledWith('body', '%kernel%');
-    expect(body['review-1']).toMatchObject({
-      reviewId: 'review-1',
-      reviewerId: '',
-      body: '',
-      workload: 0,
-      difficulty: 3,
-      overall: 3,
-      modified: new Date('2025-08-02T00:00:00.000Z').getTime(),
-    });
-  });
-
-  it('returns paginated reviews with capped limits', async () => {
-    query = makeQuery({ data: [], error: null, count: 150 });
-    mockCreateClient.mockResolvedValue({ from: jest.fn(() => query) });
-
-    const response = await GET(
-      makeRequest('/api/reviews?courseId=CS-6200&paginated=true&limit=999&offset=20')
+      makeRequest(
+        '/api/reviews?courseId=CS-6200&year=2025&semester=fa&search=kernel&limit=5&offset=10&paginated=true'
+      )
     );
 
-    expect(query.range).toHaveBeenCalledWith(20, 119);
+    expect(mockGetPublicReviewsPage).toHaveBeenCalledWith({
+      courseId: 'CS-6200',
+      year: 2025,
+      semester: 'fa',
+      search: 'kernel',
+      limit: 5,
+      offset: 10,
+    });
     expect(response.headers.get('Cache-Control')).toBe(PUBLIC_API_CACHE_CONTROL);
     await expect(response.json()).resolves.toEqual({
-      reviews: {},
-      pagination: {
-        offset: 20,
-        limit: 100,
-        total: 150,
-        hasMore: true,
+      reviews: {
+        'review-1': expect.objectContaining({
+          reviewId: 'review-1',
+          courseId: 'CS-6200',
+          body: 'Great course',
+        }),
       },
+      pagination: { offset: 10, limit: 5, hasMore: false },
     });
   });
 
-  it('defaults paginated null data and count', async () => {
-    query = makeQuery({ data: null, error: null, count: null });
-    mockCreateClient.mockResolvedValue({ from: jest.fn(() => query) });
+  it.each([
+    '/api/reviews?courseId=CS-6200&limit=0',
+    '/api/reviews?courseId=CS-6200&offset=-1',
+    '/api/reviews?courseId=CS-6200&year=1999',
+    '/api/reviews?courseId=CS-6200&semester=wi',
+    '/api/reviews?courseId=CS-6200&search=x',
+  ])('rejects invalid filters: %s', async (path) => {
+    const response = await GET(makeRequest(path));
+    expect(response.status).toBe(400);
+    expect(mockGetPublicReviewsPage).not.toHaveBeenCalled();
+  });
 
+  it('returns an uncached 503 when public reads fail', async () => {
+    mockGetPublicReviewsPage.mockRejectedValueOnce(new Error('restricted'));
     const response = await GET(
-      makeRequest('/api/reviews?courseId=CS-6200&paginated=true')
+      makeRequest('/api/reviews?courseId=CS-6200')
     );
-
-    await expect(response.json()).resolves.toEqual({
-      reviews: {},
-      pagination: {
-        offset: 0,
-        limit: 20,
-        total: 0,
-        hasMore: false,
-      },
-    });
-  });
-
-  it('returns a 500 when review lookup returns an error', async () => {
-    query = makeQuery({ data: null, error: new Error('select failed') });
-    mockCreateClient.mockResolvedValue({ from: jest.fn(() => query) });
-
-    const response = await GET(makeRequest('/api/reviews?courseId=CS-6200'));
-
-    expect(response.status).toBe(500);
-    await expect(response.json()).resolves.toEqual({ error: 'Failed to fetch reviews' });
-  });
-
-  it('returns a 500 when review lookup throws', async () => {
-    mockCreateClient.mockRejectedValueOnce(new Error('client failed'));
-
-    const response = await GET(makeRequest('/api/reviews?courseId=CS-6200'));
-
-    expect(response.status).toBe(500);
-    await expect(response.json()).resolves.toEqual({ error: 'Failed to fetch reviews' });
+    expect(response.status).toBe(503);
+    expect(response.headers.get('Cache-Control')).toBe('private, no-store');
   });
 
   it('requires authentication before creating a review', async () => {
-    mockAuthGetUser.mockResolvedValueOnce({ data: { user: null }, error: null });
-
-    const response = await POST(
-      makeRequest('/api/reviews', { method: 'POST', body: JSON.stringify({}) })
-    );
-
-    expect(response.status).toBe(401);
-  });
-
-  it('creates reviews for the authenticated user', async () => {
-    query = makeQuery({ data: { id: 'review-1' }, error: null });
-    const from = jest.fn(() => query);
-    mockCreateClient.mockResolvedValue({ auth: { getUser: mockAuthGetUser }, from });
-
-    const response = await POST(
-      makeRequest('/api/reviews', {
-        method: 'POST',
-        body: JSON.stringify({
-          reviewId: 'review-1',
-          courseId: 'CS-6200',
-          year: 2025,
-          semesterId: 'fa',
-          body: 'great',
-          workload: 10,
-          difficulty: 3,
-          overall: 4,
-        }),
-      })
-    );
-
-    expect(response.status).toBe(200);
-    expect(query.insert).toHaveBeenCalledWith(
-      expect.objectContaining({
-        id: 'review-1',
-        reviewer_id: 'user-1',
-        is_gt_verified: true,
-        upvotes: 0,
-        downvotes: 0,
-      })
-    );
-    await expect(response.json()).resolves.toEqual({ review: { id: 'review-1' } });
-  });
-
-  it('creates non-GT reviews when the authenticated user has another email', async () => {
-    mockAuthGetUser.mockResolvedValueOnce({
-      data: { user: { id: 'user-1', email: 'person@example.com' } },
-      error: null,
-    });
-    query = makeQuery({ data: { id: 'review-1' }, error: null });
-    mockCreateClient.mockResolvedValue({ auth: { getUser: mockAuthGetUser }, from: jest.fn(() => query) });
-
+    mockGetAuthenticatedClaims.mockResolvedValueOnce(null);
     const response = await POST(
       makeRequest('/api/reviews', {
         method: 'POST',
         body: JSON.stringify({ reviewId: 'review-1' }),
       })
     );
+    expect(response.status).toBe(401);
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it('creates reviews and invalidates course and recent caches', async () => {
+    const body = {
+      reviewId: 'review-2',
+      courseId: 'CS-6250',
+      year: 2026,
+      semesterId: 'sp',
+      body: 'Solid',
+      workload: 8,
+      difficulty: 2,
+      overall: 4,
+    };
+    const response = await POST(
+      makeRequest('/api/reviews', {
+        method: 'POST',
+        body: JSON.stringify(body),
+      })
+    );
 
     expect(response.status).toBe(200);
-    expect(query.insert).toHaveBeenCalledWith(
-      expect.objectContaining({ is_gt_verified: false })
+    expect(mockInsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'review-2',
+        reviewer_id: 'user-1',
+        is_gt_verified: true,
+      })
     );
+    expect(revalidateTag).toHaveBeenCalledWith(
+      'reviews:course:CS-6250',
+      'max'
+    );
+    expect(revalidateTag).toHaveBeenCalledWith('reviews:recent', 'max');
+    expect(revalidatePath).toHaveBeenCalledWith('/course/CS-6250');
+    expect(revalidatePath).toHaveBeenCalledWith('/recents');
   });
 
-  it('returns a 500 when insert fails', async () => {
-    query = makeQuery({ data: null, error: new Error('insert failed') });
-    mockCreateClient.mockResolvedValue({ auth: { getUser: mockAuthGetUser }, from: jest.fn(() => query) });
-
+  it('returns a 500 when insertion fails', async () => {
+    mockInsert.mockResolvedValueOnce({ error: { message: 'insert failed' } });
     const response = await POST(
-      makeRequest('/api/reviews', { method: 'POST', body: JSON.stringify({}) })
+      makeRequest('/api/reviews', {
+        method: 'POST',
+        body: JSON.stringify({ reviewId: 'review-1', courseId: 'CS-6200' }),
+      })
     );
-
     expect(response.status).toBe(500);
-    await expect(response.json()).resolves.toEqual({ error: 'Failed to create review' });
-  });
-
-  it('returns a 500 for malformed request bodies', async () => {
-    const response = await POST(
-      makeRequest('/api/reviews', { method: 'POST', body: '{' })
-    );
-
-    expect(response.status).toBe(500);
-    await expect(response.json()).resolves.toEqual({ error: 'Internal server error' });
+    await expect(response.json()).resolves.toEqual({
+      error: 'Failed to create review',
+    });
   });
 });

--- a/app/api/reviews/route.ts
+++ b/app/api/reviews/route.ts
@@ -1,50 +1,42 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
-import type { Database } from '@/lib/supabase/database.types';
-import { TCourseId, TPayloadReviews } from '@/lib/types';
-import { publicApiJson } from '@/lib/cacheHeaders';
-
-type SupabaseReview = Database['public']['Tables']['reviews']['Row'];
+import { getAuthenticatedClaims } from '@/lib/supabase/auth';
+import { revalidatePath, revalidateTag } from 'next/cache';
+import { publicApiJson, uncachedApiJson } from '@/lib/cacheHeaders';
+import { mapSupabaseReviewToReview } from '@/lib/supabase/mappers';
+import {
+  courseReviewsCacheTag,
+  getPublicReviewsPage,
+  MAX_PUBLIC_REVIEW_LIMIT,
+  MAX_PUBLIC_REVIEW_OFFSET,
+  MAX_PUBLIC_REVIEW_SEARCH_LENGTH,
+  RECENT_REVIEWS_CACHE_TAG,
+  type PublicReviewRow,
+} from '@/lib/supabase/publicReviews';
+import { TPayloadReviews } from '@/lib/types';
 
 // Convert Supabase reviews array to TPayloadReviews object format
-function mapSupabaseReviewsToPayload(reviews: SupabaseReview[]): TPayloadReviews {
+function mapSupabaseReviewsToPayload(
+  reviews: PublicReviewRow[]
+): TPayloadReviews {
   const payload: TPayloadReviews = {};
   reviews.forEach((review) => {
-    payload[review.id] = {
-      reviewId: review.id,
-      courseId: review.course_id as TCourseId,
-      year: review.year,
-      semesterId: review.semester as 'sp' | 'sm' | 'fa',
-      isLegacy: review.is_legacy,
-      reviewerId: review.reviewer_id ?? '',
-      isGTVerifiedReviewer: review.is_gt_verified,
-      created: new Date(review.created_at).getTime(),
-      modified: review.modified_at ? new Date(review.modified_at).getTime() : null,
-      body: review.body ?? '',
-      upvotes: review.upvotes,
-      downvotes: review.downvotes,
-      workload: review.workload ?? 0,
-      difficulty: (review.difficulty ?? 3) as 1 | 2 | 3 | 4 | 5,
-      overall: (review.overall ?? 3) as 1 | 2 | 3 | 4 | 5,
-      staffSupport: review.staff_support as 1 | 2 | 3 | 4 | 5 | undefined,
-      isRecommended: review.is_recommended ?? undefined,
-      isGoodFirstCourse: review.is_good_first_course ?? undefined,
-      isPairable: review.is_pairable ?? undefined,
-      hasGroupProjects: review.has_group_projects ?? undefined,
-      hasWritingAssignments: review.has_writing_assignments ?? undefined,
-      hasExamsQuizzes: review.has_exams_quizzes ?? undefined,
-      hasMandatoryReadings: review.has_mandatory_readings ?? undefined,
-      hasProgrammingAssignments: review.has_programming_assignments ?? undefined,
-      hasProvidedDevEnv: review.has_provided_dev_env ?? undefined,
-      programmingLanguagesIds: review.programming_languages as any,
-      preparation: review.preparation as 1 | 2 | 3 | 4 | 5 | undefined,
-      omsCoursesTaken: review.oms_courses_taken,
-      hasRelevantWorkExperience: review.has_relevant_work_experience ?? undefined,
-      experienceLevelId: review.experience_level as 'jr' | 'mid' | 'sr' | undefined,
-      gradeId: review.grade ?? undefined,
-    };
+    payload[review.id] = mapSupabaseReviewToReview(review);
   });
   return payload;
+}
+
+function parseInteger(value: string | null, fallback: number) {
+  if (value === null) return fallback;
+  const parsed = Number(value);
+  return Number.isInteger(parsed) ? parsed : null;
+}
+
+function invalidateReviewCaches(courseId: string) {
+  revalidateTag(courseReviewsCacheTag(courseId), 'max');
+  revalidateTag(RECENT_REVIEWS_CACHE_TAG, 'max');
+  revalidatePath(`/course/${courseId}`);
+  revalidatePath('/recents');
 }
 
 export async function GET(request: NextRequest) {
@@ -53,41 +45,49 @@ export async function GET(request: NextRequest) {
   const year = searchParams.get('year');
   const semester = searchParams.get('semester');
   const search = searchParams.get('search')?.trim() || '';
-  const limit = Math.min(parseInt(searchParams.get('limit') || '20', 10), 100);
-  const offset = parseInt(searchParams.get('offset') || '0', 10);
+  const limit = parseInteger(searchParams.get('limit'), 20);
+  const offset = parseInteger(searchParams.get('offset'), 0);
   const paginated = searchParams.get('paginated') === 'true';
 
-  if (!courseId) {
-    return NextResponse.json({ error: 'courseId is required' }, { status: 400 });
+  if (!courseId || !/^[A-Za-z0-9-]{2,32}$/.test(courseId)) {
+    return uncachedApiJson({ error: 'A valid courseId is required' }, { status: 400 });
+  }
+  if (
+    limit === null ||
+    limit < 1 ||
+    limit > MAX_PUBLIC_REVIEW_LIMIT ||
+    offset === null ||
+    offset < 0 ||
+    offset > MAX_PUBLIC_REVIEW_OFFSET
+  ) {
+    return uncachedApiJson({ error: 'Invalid pagination parameters' }, { status: 400 });
+  }
+  if (year && (!/^\d{4}$/.test(year) || Number(year) < 2000 || Number(year) > 2100)) {
+    return uncachedApiJson({ error: 'Invalid year' }, { status: 400 });
+  }
+  if (semester && !['sp', 'sm', 'fa'].includes(semester)) {
+    return uncachedApiJson({ error: 'Invalid semester' }, { status: 400 });
+  }
+  if (
+    search &&
+    (search.length < 2 || search.length > MAX_PUBLIC_REVIEW_SEARCH_LENGTH)
+  ) {
+    return uncachedApiJson(
+      { error: 'Search must be between 2 and 100 characters' },
+      { status: 400 }
+    );
   }
 
   try {
-    const supabase = await createClient();
-
-    // Build query
-    let query = supabase
-      .from('reviews')
-      .select('*', { count: paginated ? 'exact' : undefined })
-      .eq('course_id', courseId)
-      .order('created_at', { ascending: false });
-
-    if (year) query = query.eq('year', parseInt(year, 10));
-    if (semester) query = query.eq('semester', semester);
-    if (search) query = query.ilike('body', `%${search}%`);
-
-    // Apply pagination if requested
-    if (paginated) {
-      query = query.range(offset, offset + limit - 1);
-    }
-
-    const { data: supabaseReviews, error, count } = await query;
-
-    if (error) {
-      console.error('Error fetching reviews:', error);
-      return NextResponse.json({ error: 'Failed to fetch reviews' }, { status: 500 });
-    }
-
-    const reviews = mapSupabaseReviewsToPayload(supabaseReviews || []);
+    const reviewPage = await getPublicReviewsPage({
+      courseId,
+      year: year ? Number(year) : undefined,
+      semester: semester || undefined,
+      search: search || undefined,
+      limit,
+      offset: paginated ? offset : 0,
+    });
+    const reviews = mapSupabaseReviewsToPayload(reviewPage.reviews);
 
     // Return paginated response if requested
     if (paginated) {
@@ -96,8 +96,7 @@ export async function GET(request: NextRequest) {
         pagination: {
           offset,
           limit,
-          total: count || 0,
-          hasMore: (offset + limit) < (count || 0),
+          hasMore: reviewPage.hasMore,
         },
       });
     }
@@ -106,7 +105,7 @@ export async function GET(request: NextRequest) {
     return publicApiJson(reviews);
   } catch (error) {
     console.error('Error fetching reviews:', error);
-    return NextResponse.json({ error: 'Failed to fetch reviews' }, { status: 500 });
+    return uncachedApiJson({ error: 'Failed to fetch reviews' }, { status: 503 });
   }
 }
 
@@ -116,22 +115,21 @@ export async function POST(request: NextRequest) {
     const body = await request.json();
     const supabase = await createClient();
 
-    // Get the current user
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
-    if (authError || !user) {
+    const auth = await getAuthenticatedClaims(supabase);
+    if (!auth) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
     // Check user's email for GT verification
-    const isGTVerified = user.email?.endsWith('@gatech.edu') || false;
+    const isGTVerified = auth.email?.endsWith('@gatech.edu') || false;
 
     // Create the review
-    const { data: review, error: insertError } = await supabase
+    const { error: insertError } = await supabase
       .from('reviews')
       .insert({
         id: body.reviewId,
         course_id: body.courseId,
-        reviewer_id: user.id,
+        reviewer_id: auth.userId,
         year: body.year,
         semester: body.semesterId,
         body: body.body,
@@ -142,16 +140,15 @@ export async function POST(request: NextRequest) {
         is_gt_verified: isGTVerified,
         upvotes: 0,
         downvotes: 0,
-      })
-      .select()
-      .single();
+      });
 
     if (insertError) {
       console.error('Error creating review:', insertError);
       return NextResponse.json({ error: 'Failed to create review' }, { status: 500 });
     }
 
-    return NextResponse.json({ review });
+    invalidateReviewCaches(body.courseId);
+    return NextResponse.json({ success: true });
   } catch (error) {
     console.error('Error in POST /api/reviews:', error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });

--- a/app/api/user/reviews/route.test.ts
+++ b/app/api/user/reviews/route.test.ts
@@ -4,24 +4,58 @@
 
 import { GET } from './route';
 
-const mockGetUserReviews = jest.fn();
-const mockAuthGetUser = jest.fn();
+const mockGetAuthenticatedClaims = jest.fn();
+const mockLimit = jest.fn();
+const mockOrder = jest.fn(() => ({ limit: mockLimit }));
+const mockEq = jest.fn(() => ({ order: mockOrder }));
+const mockSelect = jest.fn(() => ({ eq: mockEq }));
+const mockFrom = jest.fn(() => ({ select: mockSelect }));
 
-jest.mock('@/lib/supabase/dbOperations', () => ({
-  getUserReviews: (...args: unknown[]) => mockGetUserReviews(...args),
+jest.mock('@/lib/supabase/auth', () => ({
+  getAuthenticatedClaims: (...args: unknown[]) =>
+    mockGetAuthenticatedClaims(...args),
 }));
 
 jest.mock('@/lib/supabase/server', () => ({
-  createClient: jest.fn(() => ({
-    auth: {
-      getUser: mockAuthGetUser,
-    },
-  })),
+  createClient: jest.fn(async () => ({ from: mockFrom })),
 }));
 
-function makeRequest(path: string) {
-  return new Request(`https://www.omshub.org${path}`);
-}
+const makeRequest = (path: string) =>
+  new Request(`https://www.omshub.org${path}`) as any;
+
+const review = {
+  id: 'review-1',
+  course_id: 'CS-6200',
+  reviewer_id: 'user-1',
+  year: 2025,
+  semester: 'fa',
+  body: 'Great course',
+  workload: 10,
+  difficulty: 3,
+  overall: 5,
+  staff_support: 4,
+  is_legacy: false,
+  is_gt_verified: true,
+  upvotes: 2,
+  downvotes: 0,
+  is_recommended: true,
+  is_good_first_course: false,
+  is_pairable: true,
+  has_group_projects: false,
+  has_writing_assignments: false,
+  has_exams_quizzes: true,
+  has_mandatory_readings: false,
+  has_programming_assignments: true,
+  has_provided_dev_env: true,
+  programming_languages: ['python'],
+  preparation: 3,
+  oms_courses_taken: 2,
+  has_relevant_work_experience: true,
+  experience_level: 'mid',
+  grade: 'A',
+  created_at: '2025-08-01T00:00:00.000Z',
+  modified_at: null,
+};
 
 describe('/api/user/reviews', () => {
   let consoleErrorSpy: jest.SpyInstance;
@@ -29,145 +63,65 @@ describe('/api/user/reviews', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-    mockAuthGetUser.mockResolvedValue({
-      data: { user: { id: 'user-1' } },
+    mockGetAuthenticatedClaims.mockResolvedValue({ userId: 'user-1' });
+    mockLimit.mockResolvedValue({ data: [review], error: null });
+  });
+
+  afterEach(() => consoleErrorSpy.mockRestore());
+
+  it('requires verified claims and ignores caller-supplied ownership', async () => {
+    mockGetAuthenticatedClaims.mockResolvedValueOnce(null);
+    const response = await GET(
+      makeRequest('/api/user/reviews?userId=someone-else')
+    );
+    expect(response.status).toBe(401);
+    expect(response.headers.get('Cache-Control')).toBe('private, no-store');
+    expect(mockFrom).not.toHaveBeenCalled();
+  });
+
+  it('returns a bounded summary for duplicate-review checks', async () => {
+    mockLimit.mockResolvedValueOnce({
+      data: [
+        { course_id: 'CS-6200', year: 2025, semester: 'fa' },
+        { course_id: 'CS-6250', year: 2024, semester: 'sp' },
+      ],
       error: null,
+    });
+    const response = await GET(
+      makeRequest('/api/user/reviews?summary=true')
+    );
+
+    expect(mockSelect).toHaveBeenCalledWith('course_id,year,semester');
+    expect(mockEq).toHaveBeenCalledWith('reviewer_id', 'user-1');
+    expect(mockLimit).toHaveBeenCalledWith(200);
+    expect(response.headers.get('Cache-Control')).toBe('private, no-store');
+    await expect(response.json()).resolves.toEqual({
+      reviewKeys: ['CS-6200-2025-3', 'CS-6250-2024-1'],
     });
   });
 
-  afterEach(() => {
-    consoleErrorSpy.mockRestore();
-  });
-
-  it('requires authentication', async () => {
-    mockAuthGetUser.mockResolvedValueOnce({ data: { user: null }, error: null });
-
-    const response = await GET(makeRequest('/api/user/reviews?userId=user-1'));
-
-    expect(response.status).toBe(401);
-    expect(mockGetUserReviews).not.toHaveBeenCalled();
-  });
-
-  it('requires userId', async () => {
+  it('returns the authenticated user review payload', async () => {
     const response = await GET(makeRequest('/api/user/reviews'));
+    expect(mockEq).toHaveBeenCalledWith('reviewer_id', 'user-1');
+    expect(mockLimit).toHaveBeenCalledWith(200);
+    expect(response.headers.get('Cache-Control')).toBe('private, no-store');
     const body = await response.json();
-
-    expect(response.status).toBe(400);
-    expect(body).toEqual({ error: 'userId is required' });
-    expect(mockAuthGetUser).not.toHaveBeenCalled();
-  });
-
-  it('forbids requesting another user review list', async () => {
-    const response = await GET(makeRequest('/api/user/reviews?userId=user-2'));
-
-    expect(response.status).toBe(403);
-    expect(mockGetUserReviews).not.toHaveBeenCalled();
-  });
-
-  it('maps Supabase reviews to the client payload shape', async () => {
-    mockGetUserReviews.mockResolvedValueOnce([
-      {
-        id: 'review-1',
-        course_id: 'CS-6200',
-        year: 2025,
-        semester: 'fa',
-        is_legacy: false,
-        reviewer_id: null,
-        is_gt_verified: true,
-        created_at: '2025-08-01T00:00:00.000Z',
-        modified_at: '2025-08-02T00:00:00.000Z',
-        body: null,
-        upvotes: 3,
-        downvotes: 1,
-        workload: null,
-        difficulty: null,
-        overall: null,
-        staff_support: 4,
-        is_recommended: null,
-        is_good_first_course: true,
-        is_pairable: false,
-        has_group_projects: true,
-        has_writing_assignments: false,
-        has_exams_quizzes: true,
-        has_mandatory_readings: false,
-        has_programming_assignments: true,
-        has_provided_dev_env: false,
-        programming_languages: ['c'],
-        preparation: 5,
-        oms_courses_taken: 2,
-        has_relevant_work_experience: true,
-        experience_level: 'sr',
-        grade: 'A',
-      },
-      {
-        id: 'review-2',
-        course_id: 'CS-6250',
-        year: 2024,
-        semester: 'sp',
-        is_legacy: true,
-        reviewer_id: 'user-1',
-        is_gt_verified: false,
-        created_at: '2024-01-01T00:00:00.000Z',
-        modified_at: null,
-        body: 'solid course',
-        upvotes: 0,
-        downvotes: 0,
-        workload: 8,
-        difficulty: 2,
-        overall: 4,
-        staff_support: null,
-        is_recommended: true,
-        is_good_first_course: null,
-        is_pairable: null,
-        has_group_projects: null,
-        has_writing_assignments: null,
-        has_exams_quizzes: null,
-        has_mandatory_readings: null,
-        has_programming_assignments: null,
-        has_provided_dev_env: null,
-        programming_languages: null,
-        preparation: null,
-        oms_courses_taken: 1,
-        has_relevant_work_experience: null,
-        experience_level: null,
-        grade: null,
-      },
-    ]);
-
-    const response = await GET(makeRequest('/api/user/reviews?userId=user-1'));
-    const body = await response.json();
-
-    expect(response.status).toBe(200);
     expect(body['review-1']).toMatchObject({
       reviewId: 'review-1',
       courseId: 'CS-6200',
-      semesterId: 'fa',
-      reviewerId: '',
-      body: '',
-      workload: 0,
-      difficulty: 3,
-      overall: 3,
-      isGoodFirstCourse: true,
-    });
-    expect(body['review-2']).toMatchObject({
-      reviewId: 'review-2',
-      modified: null,
       reviewerId: 'user-1',
-      body: 'solid course',
-      workload: 8,
-      difficulty: 2,
-      overall: 4,
-      staffSupport: null,
+      body: 'Great course',
+      programmingLanguagesIds: ['python'],
     });
   });
 
-  it('returns a 500 when review lookup fails', async () => {
-    mockGetUserReviews.mockRejectedValueOnce(new Error('reviews unavailable'));
-
-    const response = await GET(makeRequest('/api/user/reviews?userId=user-1'));
-    const body = await response.json();
-
+  it('returns a private 500 when review lookup fails', async () => {
+    mockLimit.mockResolvedValueOnce({
+      data: null,
+      error: { message: 'lookup failed' },
+    });
+    const response = await GET(makeRequest('/api/user/reviews'));
     expect(response.status).toBe(500);
-    expect(body).toEqual({ error: 'Failed to fetch user reviews' });
+    expect(response.headers.get('Cache-Control')).toBe('private, no-store');
   });
 });

--- a/app/api/user/reviews/route.ts
+++ b/app/api/user/reviews/route.ts
@@ -1,10 +1,46 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { getUserReviews } from '@/lib/supabase/dbOperations';
+import { NextRequest } from 'next/server';
+import { getAuthenticatedClaims } from '@/lib/supabase/auth';
 import { createClient } from '@/lib/supabase/server';
 import type { Database } from '@/lib/supabase/database.types';
+import { uncachedApiJson } from '@/lib/cacheHeaders';
 import { TCourseId, TPayloadReviews } from '@/lib/types';
 
 type SupabaseReview = Database['public']['Tables']['reviews']['Row'];
+const MAX_USER_REVIEWS = 200;
+const USER_REVIEW_COLUMNS = [
+  'id',
+  'course_id',
+  'reviewer_id',
+  'year',
+  'semester',
+  'body',
+  'workload',
+  'difficulty',
+  'overall',
+  'staff_support',
+  'is_legacy',
+  'is_gt_verified',
+  'upvotes',
+  'downvotes',
+  'is_recommended',
+  'is_good_first_course',
+  'is_pairable',
+  'has_group_projects',
+  'has_writing_assignments',
+  'has_exams_quizzes',
+  'has_mandatory_readings',
+  'has_programming_assignments',
+  'has_provided_dev_env',
+  'programming_languages',
+  'preparation',
+  'oms_courses_taken',
+  'has_relevant_work_experience',
+  'experience_level',
+  'grade',
+  'created_at',
+  'modified_at',
+].join(',');
+const SEMESTER_TERM: Record<string, number> = { sp: 1, sm: 2, fa: 3 };
 
 // Convert Supabase reviews array to TPayloadReviews object format (keyed by reviewId)
 function mapSupabaseReviewsToPayload(reviews: SupabaseReview[]): TPayloadReviews {
@@ -49,32 +85,50 @@ function mapSupabaseReviewsToPayload(reviews: SupabaseReview[]): TPayloadReviews
 
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
-  const userId = searchParams.get('userId');
+  const summaryOnly = searchParams.get('summary') === 'true';
+  const supabase = await createClient();
+  const auth = await getAuthenticatedClaims(supabase);
 
-  if (!userId) {
-    return NextResponse.json({ error: 'userId is required' }, { status: 400 });
+  if (!auth) {
+    return uncachedApiJson({ error: 'Unauthorized' }, { status: 401 });
   }
 
   try {
-    const supabase = await createClient();
-    const {
-      data: { user },
-      error: authError,
-    } = await supabase.auth.getUser();
+    if (summaryOnly) {
+      const { data, error } = await supabase
+        .from('reviews')
+        .select('course_id,year,semester')
+        .eq('reviewer_id', auth.userId)
+        .order('created_at', { ascending: false })
+        .limit(MAX_USER_REVIEWS);
 
-    if (authError || !user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+      if (error) throw error;
+
+      const reviewKeys = (data ?? []).map(
+        (review) =>
+          `${review.course_id}-${review.year}-${SEMESTER_TERM[review.semester] ?? 0}`
+      );
+      return uncachedApiJson({ reviewKeys });
     }
 
-    if (user.id !== userId) {
-      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
-    }
+    const { data, error } = await supabase
+      .from('reviews')
+      .select(USER_REVIEW_COLUMNS)
+      .eq('reviewer_id', auth.userId)
+      .order('created_at', { ascending: false })
+      .limit(MAX_USER_REVIEWS);
 
-    const supabaseReviews = await getUserReviews(userId);
-    const reviews = mapSupabaseReviewsToPayload(supabaseReviews);
-    return NextResponse.json(reviews);
+    if (error) throw error;
+
+    const reviews = mapSupabaseReviewsToPayload(
+      (data ?? []) as unknown as SupabaseReview[]
+    );
+    return uncachedApiJson(reviews);
   } catch (error) {
     console.error('Error fetching user reviews:', error);
-    return NextResponse.json({ error: 'Failed to fetch user reviews' }, { status: 500 });
+    return uncachedApiJson(
+      { error: 'Failed to fetch user reviews' },
+      { status: 500 }
+    );
   }
 }

--- a/app/api/user/route.test.ts
+++ b/app/api/user/route.test.ts
@@ -4,26 +4,26 @@
 
 import { GET, POST } from './route';
 
-const mockGetUserProfile = jest.fn();
-const mockAddUser = jest.fn();
-const mockAuthGetUser = jest.fn();
+const mockGetAuthenticatedClaims = jest.fn();
+const mockMaybeSingle = jest.fn();
+const mockGetEq = jest.fn(() => ({ maybeSingle: mockMaybeSingle }));
+const mockGetSelect = jest.fn(() => ({ eq: mockGetEq }));
+const mockPostSingle = jest.fn();
+const mockPostSelect = jest.fn(() => ({ single: mockPostSingle }));
+const mockUpsert = jest.fn(() => ({ select: mockPostSelect }));
+const mockFrom = jest.fn(() => ({
+  select: mockGetSelect,
+  upsert: mockUpsert,
+}));
 
-jest.mock('@/lib/supabase/dbOperations', () => ({
-  getUser: (...args: unknown[]) => mockGetUserProfile(...args),
-  addUser: (...args: unknown[]) => mockAddUser(...args),
+jest.mock('@/lib/supabase/auth', () => ({
+  getAuthenticatedClaims: (...args: unknown[]) =>
+    mockGetAuthenticatedClaims(...args),
 }));
 
 jest.mock('@/lib/supabase/server', () => ({
-  createClient: jest.fn(() => ({
-    auth: {
-      getUser: mockAuthGetUser,
-    },
-  })),
+  createClient: jest.fn(async () => ({ from: mockFrom })),
 }));
-
-function makeRequest(path: string, init?: RequestInit) {
-  return new Request(`https://www.omshub.org${path}`, init);
-}
 
 describe('/api/user', () => {
   let consoleErrorSpy: jest.SpyInstance;
@@ -31,133 +31,57 @@ describe('/api/user', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-    mockAuthGetUser.mockResolvedValue({
-      data: { user: { id: 'user-1', email: 'student@gatech.edu' } },
-      error: null,
-    });
-  });
-
-  afterEach(() => {
-    consoleErrorSpy.mockRestore();
-  });
-
-  it('requires authentication before creating a profile', async () => {
-    mockAuthGetUser.mockResolvedValueOnce({ data: { user: null }, error: null });
-
-    const response = await POST(
-      makeRequest('/api/user', {
-        method: 'POST',
-        body: JSON.stringify({ userId: 'attacker', hasGTEmail: true }),
-      })
-    );
-
-    expect(response.status).toBe(401);
-    expect(mockAddUser).not.toHaveBeenCalled();
-  });
-
-  it('creates profiles for the authenticated user and derives GT email server-side', async () => {
-    mockAuthGetUser.mockResolvedValueOnce({
-      data: { user: { id: 'user-1', email: 'person@gmail.com' } },
-      error: null,
-    });
-    mockGetUserProfile.mockResolvedValueOnce(null);
-    mockAddUser.mockResolvedValueOnce({ id: 'user-1', has_gt_email: false });
-
-    const response = await POST(
-      makeRequest('/api/user', {
-        method: 'POST',
-        body: JSON.stringify({ userId: 'attacker', hasGTEmail: true }),
-      })
-    );
-
-    expect(response.status).toBe(200);
-    expect(mockAddUser).toHaveBeenCalledWith({
-      id: 'user-1',
-      has_gt_email: false,
-    });
-  });
-
-  it('treats missing authenticated email as non-GT when creating a profile', async () => {
-    mockAuthGetUser.mockResolvedValueOnce({
-      data: { user: { id: 'user-1' } },
-      error: null,
-    });
-    mockGetUserProfile.mockResolvedValueOnce(null);
-    mockAddUser.mockResolvedValueOnce({ id: 'user-1', has_gt_email: false });
-
-    const response = await POST(makeRequest('/api/user', { method: 'POST' }));
-
-    expect(response.status).toBe(200);
-    expect(mockAddUser).toHaveBeenCalledWith({
-      id: 'user-1',
-      has_gt_email: false,
-    });
-  });
-
-  it('returns an existing authenticated profile without inserting a duplicate', async () => {
-    mockGetUserProfile.mockResolvedValueOnce({
-      id: 'user-1',
-      has_gt_email: true,
-    });
-
-    const response = await POST(makeRequest('/api/user', { method: 'POST' }));
-    const body = await response.json();
-
-    expect(response.status).toBe(200);
-    expect(body).toEqual({
+    mockGetAuthenticatedClaims.mockResolvedValue({
       userId: 'user-1',
-      hasGTEmail: true,
+      email: 'student@gatech.edu',
+    });
+    mockMaybeSingle.mockResolvedValue({ data: null, error: null });
+    mockPostSingle.mockResolvedValue({
+      data: { id: 'user-1', has_gt_email: true },
+      error: null,
+    });
+  });
+
+  afterEach(() => consoleErrorSpy.mockRestore());
+
+  it.each([GET, POST])('requires verified claims', async (handler) => {
+    mockGetAuthenticatedClaims.mockResolvedValueOnce(null);
+    const response = await handler();
+    expect(response.status).toBe(401);
+    expect(response.headers.get('Cache-Control')).toBe('private, no-store');
+    expect(mockFrom).not.toHaveBeenCalled();
+  });
+
+  it('returns an empty private payload when the profile does not exist', async () => {
+    const response = await GET();
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Cache-Control')).toBe('private, no-store');
+    await expect(response.json()).resolves.toEqual({
+      userId: null,
+      hasGTEmail: false,
       reviews: {},
     });
-    expect(mockAddUser).not.toHaveBeenCalled();
   });
 
-  it('requires userId when fetching a profile', async () => {
-    const response = await GET(makeRequest('/api/user'));
-    const body = await response.json();
-
-    expect(response.status).toBe(400);
-    expect(body).toEqual({ error: 'userId is required' });
-    expect(mockAuthGetUser).not.toHaveBeenCalled();
-  });
-
-  it('requires authentication before fetching a profile', async () => {
-    mockAuthGetUser.mockResolvedValueOnce({ data: { user: null }, error: null });
-
-    const response = await GET(makeRequest('/api/user?userId=user-1'));
-
-    expect(response.status).toBe(401);
-    expect(mockGetUserProfile).not.toHaveBeenCalled();
-  });
-
-  it('returns an empty payload when the authenticated profile does not exist', async () => {
-    mockGetUserProfile.mockResolvedValueOnce(null);
-
-    const response = await GET(makeRequest('/api/user?userId=user-1'));
-    const body = await response.json();
-
-    expect(response.status).toBe(200);
-    expect(body).toEqual({ userId: null, hasGTEmail: false, reviews: {} });
-  });
-
-  it('returns the authenticated user profile with onboarding fields', async () => {
-    mockGetUserProfile.mockResolvedValueOnce({
-      id: 'user-1',
-      has_gt_email: true,
-      education_level: 'ms',
-      subject_area: 'cs',
-      work_years: 4,
-      specialization: 'ml',
+  it('returns only the authenticated profile fields', async () => {
+    mockMaybeSingle.mockResolvedValueOnce({
+      data: {
+        id: 'user-1',
+        has_gt_email: true,
+        education_level: 'mast',
+        subject_area: 'cs',
+        work_years: 4,
+        specialization: 'ml',
+      },
+      error: null,
     });
 
-    const response = await GET(makeRequest('/api/user?userId=user-1'));
-    const body = await response.json();
-
-    expect(response.status).toBe(200);
-    expect(body).toEqual({
+    const response = await GET();
+    expect(mockGetEq).toHaveBeenCalledWith('id', 'user-1');
+    await expect(response.json()).resolves.toEqual({
       userId: 'user-1',
       hasGTEmail: true,
-      educationLevelId: 'ms',
+      educationLevelId: 'mast',
       subjectAreaId: 'cs',
       workYears: 4,
       specializationId: 'ml',
@@ -165,57 +89,51 @@ describe('/api/user', () => {
     });
   });
 
-  it('returns a 500 when fetching the profile fails', async () => {
-    mockGetUserProfile.mockRejectedValueOnce(new Error('database unavailable'));
-
-    const response = await GET(makeRequest('/api/user?userId=user-1'));
-    const body = await response.json();
-
+  it('returns a private 500 when profile lookup fails', async () => {
+    mockMaybeSingle.mockResolvedValueOnce({
+      data: null,
+      error: { message: 'lookup failed' },
+    });
+    const response = await GET();
     expect(response.status).toBe(500);
-    expect(body).toEqual({ error: 'Failed to fetch user' });
+    expect(response.headers.get('Cache-Control')).toBe('private, no-store');
   });
 
-  it('returns the existing profile when insert races with another creator', async () => {
-    mockGetUserProfile
-      .mockResolvedValueOnce(null)
-      .mockResolvedValueOnce({ id: 'user-1', has_gt_email: true });
-    mockAddUser.mockRejectedValueOnce({ code: '23505', message: 'duplicate key' });
-
-    const response = await POST(makeRequest('/api/user', { method: 'POST' }));
-    const body = await response.json();
-
+  it('upserts the authenticated profile and derives GT status from claims', async () => {
+    const response = await POST();
+    expect(mockUpsert).toHaveBeenCalledWith(
+      { id: 'user-1', has_gt_email: true },
+      { onConflict: 'id' }
+    );
     expect(response.status).toBe(200);
-    expect(body).toEqual({
+    expect(response.headers.get('Cache-Control')).toBe('private, no-store');
+    await expect(response.json()).resolves.toEqual({
       userId: 'user-1',
       hasGTEmail: true,
       reviews: {},
     });
   });
 
-  it('returns a 500 when a duplicate insert race cannot reload the profile', async () => {
-    mockGetUserProfile.mockResolvedValue(null);
-    mockAddUser.mockRejectedValueOnce({ code: '23505', message: 'duplicate key' });
-
-    const response = await POST(makeRequest('/api/user', { method: 'POST' }));
-
-    expect(response.status).toBe(500);
+  it('treats missing claim email as non-GT', async () => {
+    mockGetAuthenticatedClaims.mockResolvedValueOnce({ userId: 'user-1' });
+    mockPostSingle.mockResolvedValueOnce({
+      data: { id: 'user-1', has_gt_email: false },
+      error: null,
+    });
+    await POST();
+    expect(mockUpsert).toHaveBeenCalledWith(
+      { id: 'user-1', has_gt_email: false },
+      { onConflict: 'id' }
+    );
   });
 
-  it('returns a 500 when creating a profile fails', async () => {
-    mockGetUserProfile.mockResolvedValueOnce(null);
-    mockAddUser.mockRejectedValueOnce(new Error('insert failed'));
-
-    const response = await POST(makeRequest('/api/user', { method: 'POST' }));
-    const body = await response.json();
-
+  it('returns a private 500 when profile upsert fails', async () => {
+    mockPostSingle.mockResolvedValueOnce({
+      data: null,
+      error: { message: 'upsert failed' },
+    });
+    const response = await POST();
     expect(response.status).toBe(500);
-    expect(body).toEqual({ error: 'Failed to create user' });
-  });
-
-  it('only returns the authenticated user profile', async () => {
-    const response = await GET(makeRequest('/api/user?userId=someone-else'));
-
-    expect(response.status).toBe(403);
-    expect(mockGetUserProfile).not.toHaveBeenCalled();
+    expect(response.headers.get('Cache-Control')).toBe('private, no-store');
   });
 });

--- a/app/api/user/route.ts
+++ b/app/api/user/route.ts
@@ -1,97 +1,73 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { getUser, addUser } from '@/lib/supabase/dbOperations';
+import { uncachedApiJson } from '@/lib/cacheHeaders';
+import { getAuthenticatedClaims } from '@/lib/supabase/auth';
 import { createClient } from '@/lib/supabase/server';
 
-function isUniqueViolation(error: unknown) {
-  return (error as { code?: string } | null)?.code === '23505';
-}
+const USER_PROFILE_COLUMNS =
+  'id,has_gt_email,education_level,subject_area,work_years,specialization';
 
-function userResponse(user: { id: string; has_gt_email: boolean }) {
-  return NextResponse.json({
-    userId: user.id,
-    hasGTEmail: user.has_gt_email,
-    reviews: {},
-  });
-}
-
-async function getAuthenticatedUser() {
+export async function GET() {
   const supabase = await createClient();
-  const {
-    data: { user },
-    error,
-  } = await supabase.auth.getUser();
+  const auth = await getAuthenticatedClaims(supabase);
 
-  if (error || !user) return null;
-  return user;
-}
-
-export async function GET(request: NextRequest) {
-  const { searchParams } = new URL(request.url);
-  const userId = searchParams.get('userId');
-
-  if (!userId) {
-    return NextResponse.json({ error: 'userId is required' }, { status: 400 });
+  if (!auth) {
+    return uncachedApiJson({ error: 'Unauthorized' }, { status: 401 });
   }
 
   try {
-    const authUser = await getAuthenticatedUser();
-    if (!authUser) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-    if (authUser.id !== userId) {
-      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    const { data: user, error } = await supabase
+      .from('users')
+      .select(USER_PROFILE_COLUMNS)
+      .eq('id', auth.userId)
+      .maybeSingle();
+
+    if (error) throw error;
+    if (!user) {
+      return uncachedApiJson({ userId: null, hasGTEmail: false, reviews: {} });
     }
 
-    const user = await getUser(userId);
-    if (!user) {
-      return NextResponse.json({ userId: null, hasGTEmail: false, reviews: {} });
-    }
-    // Return in the format expected by the client
-    return NextResponse.json({
+    return uncachedApiJson({
       userId: user.id,
       hasGTEmail: user.has_gt_email,
       educationLevelId: user.education_level,
       subjectAreaId: user.subject_area,
       workYears: user.work_years,
       specializationId: user.specialization,
-      reviews: {}, // Reviews are fetched separately via /api/user/reviews
+      reviews: {},
     });
   } catch (error) {
     console.error('Error fetching user:', error);
-    return NextResponse.json({ error: 'Failed to fetch user' }, { status: 500 });
+    return uncachedApiJson({ error: 'Failed to fetch user' }, { status: 500 });
   }
 }
 
 export async function POST() {
+  const supabase = await createClient();
+  const auth = await getAuthenticatedClaims(supabase);
+
+  if (!auth) {
+    return uncachedApiJson({ error: 'Unauthorized' }, { status: 401 });
+  }
+
   try {
-    const authUser = await getAuthenticatedUser();
-    if (!authUser) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
+    const hasGTEmail = auth.email?.endsWith('@gatech.edu') ?? false;
+    const { data: user, error } = await supabase
+      .from('users')
+      .upsert(
+        { id: auth.userId, has_gt_email: hasGTEmail },
+        { onConflict: 'id' }
+      )
+      .select('id,has_gt_email')
+      .single();
 
-    const hasGTEmail = authUser.email?.endsWith('@gatech.edu') ?? false;
-    const existingUser = await getUser(authUser.id);
+    if (error) throw error;
 
-    if (existingUser) {
-      return userResponse(existingUser);
-    }
-
-    try {
-      const user = await addUser({
-        id: authUser.id,
-        has_gt_email: hasGTEmail,
-      });
-
-      return userResponse(user);
-    } catch (error) {
-      if (isUniqueViolation(error)) {
-        const racedUser = await getUser(authUser.id);
-        if (racedUser) return userResponse(racedUser);
-      }
-      throw error;
-    }
+    return uncachedApiJson({
+      userId: user.id,
+      hasGTEmail: user.has_gt_email,
+      reviews: {},
+    });
   } catch (error) {
     console.error('Error creating user:', error);
-    return NextResponse.json({ error: 'Failed to create user' }, { status: 500 });
+    return uncachedApiJson({ error: 'Failed to create user' }, { status: 500 });
   }
 }

--- a/app/course/[courseid]/_components/CourseContent.tsx
+++ b/app/course/[courseid]/_components/CourseContent.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import ReviewCard from '@/components/ReviewCard';
-import ReviewForm from '@/components/ReviewForm';
 import CourseActionBar from '@/components/CourseActionBar';
 import { useAuth } from '@/context/AuthContext';
 import {
@@ -55,6 +54,16 @@ import {
 } from '@/utilities';
 import { useMemo, useState, useCallback, useEffect, useRef } from 'react';
 import { GT_COLORS } from '@/lib/theme';
+import dynamic from 'next/dynamic';
+
+const ReviewForm = dynamic(() => import('@/components/ReviewForm'), {
+  ssr: false,
+  loading: () => (
+    <Center py="xl">
+      <Loader size="sm" />
+    </Center>
+  ),
+});
 
 // Map semester id (sp, sm, fa) to term number (1, 2, 3)
 const semesterIdToTerm: Record<string, number> = {
@@ -124,6 +133,8 @@ export default function CourseContent({
   const [selectedSemester, setSelectedSemester] = useState<string>('all');
   const [searchQuery, setSearchQuery] = useState<string>('');
   const [debouncedSearch] = useDebouncedValue(searchQuery, 300);
+  const effectiveSearch =
+    debouncedSearch.trim().length >= 2 ? debouncedSearch.trim() : '';
   const [isSearching, setIsSearching] = useState(false);
 
   const handleCopyUrl = () => {
@@ -141,15 +152,15 @@ export default function CourseContent({
     });
     if (selectedYear !== 'all') params.set('year', selectedYear);
     if (selectedSemester !== 'all') params.set('semester', selectedSemester);
-    if (debouncedSearch) params.set('search', debouncedSearch);
+    if (effectiveSearch) params.set('search', effectiveSearch);
     return params.toString();
-  }, [courseId, selectedYear, selectedSemester, debouncedSearch]);
+  }, [courseId, selectedYear, selectedSemester, effectiveSearch]);
 
   // Reset and fetch when filters/search change
   useEffect(() => {
     const fetchFiltered = async () => {
       // Skip if we're at initial state with no filters
-      if (selectedYear === 'all' && selectedSemester === 'all' && !debouncedSearch) {
+      if (selectedYear === 'all' && selectedSemester === 'all' && !effectiveSearch) {
         // Reset to initial state if filters were cleared
         if (reviews !== initialReviews) {
           setReviews(initialReviews);
@@ -180,7 +191,7 @@ export default function CourseContent({
     };
 
     fetchFiltered();
-  }, [selectedYear, selectedSemester, debouncedSearch, buildQueryParams]);
+  }, [selectedYear, selectedSemester, effectiveSearch, buildQueryParams]);
 
   // Load more reviews
   const loadMore = useCallback(async () => {
@@ -577,9 +588,9 @@ export default function CourseContent({
                 onChange={(e) => setSearchQuery(e.currentTarget.value)}
                 aria-label="Search reviews"
               />
-              {debouncedSearch && (
+              {effectiveSearch && (
                 <Text size="sm" c="grayMatter">
-                  {filteredReviews.length} result{filteredReviews.length !== 1 ? 's' : ''} for "{debouncedSearch}"
+                  {filteredReviews.length} result{filteredReviews.length !== 1 ? 's' : ''} for "{effectiveSearch}"
                 </Text>
               )}
 
@@ -673,7 +684,7 @@ export default function CourseContent({
           <>
             <Stack gap="md">
               {filteredReviews.map((value: Review) => (
-                <ReviewCard key={value.reviewId} {...value} courseName={courseName} searchHighlight={debouncedSearch} />
+                <ReviewCard key={value.reviewId} {...value} courseName={courseName} searchHighlight={effectiveSearch} />
               ))}
             </Stack>
 
@@ -767,12 +778,14 @@ export default function CourseContent({
           centered
           radius="lg"
         >
-          <ReviewForm
-            courseId={courseId}
-            courseName={courseName}
-            reviewInput={null}
-            handleReviewModalClose={closeReviewModal}
-          />
+          {reviewModalOpened && (
+            <ReviewForm
+              courseId={courseId}
+              courseName={courseName}
+              reviewInput={null}
+              handleReviewModalClose={closeReviewModal}
+            />
+          )}
         </Modal>
       </Container>
 

--- a/app/course/[courseid]/page.tsx
+++ b/app/course/[courseid]/page.tsx
@@ -1,6 +1,10 @@
 import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
-import { createServerClient, mapSupabaseReviewsToArray } from '@/lib/supabase';
+import { mapSupabaseReviewsToArray } from '@/lib/supabase';
+import {
+  EMPTY_PUBLIC_REVIEW_PAGE,
+  getPublicReviewsPage,
+} from '@/lib/supabase/publicReviews';
 import { getCoursesDataStatic, getCourseStats } from '@/lib/staticData';
 import { TCourseId } from '@/lib/types';
 import { mapDynamicCoursesDataToCourses } from '@/lib/utilities';
@@ -8,6 +12,9 @@ import { CourseSchema, FAQSchema, BreadcrumbSchema } from '@/components/Structur
 import CourseContent from './_components/CourseContent';
 
 const PAGE_SIZE = 20;
+
+// Route segment config must remain a statically analyzable literal for Next.js.
+export const revalidate = 21600;
 
 interface CoursePageProps {
   params: Promise<{ courseid: string }>;
@@ -107,18 +114,14 @@ export default async function CoursePage({ params }: CoursePageProps) {
   const { courseid } = await params;
   const courseId = courseid as TCourseId;
 
-  const supabase = await createServerClient();
-
   // Fetch all data in parallel
-  const [allCourseDataDynamic, coursesDataStatic, { data: reviews, count }] = await Promise.all([
+  const [allCourseDataDynamic, coursesDataStatic, reviewPage] = await Promise.all([
     getCourseStats(),
     getCoursesDataStatic(),
-    supabase
-      .from('reviews')
-      .select('*', { count: 'exact' })
-      .eq('course_id', courseId)
-      .order('created_at', { ascending: false })
-      .range(0, PAGE_SIZE - 1),
+    getPublicReviewsPage({ courseId, limit: PAGE_SIZE }).catch((error) => {
+      console.error('Unable to load public course reviews:', error);
+      return EMPTY_PUBLIC_REVIEW_PAGE;
+    }),
   ]);
 
   const allCourseData = mapDynamicCoursesDataToCourses(
@@ -132,9 +135,9 @@ export default async function CoursePage({ params }: CoursePageProps) {
   }
 
   // Convert reviews to array format
-  const initialReviews = mapSupabaseReviewsToArray(reviews || []);
-  const totalReviewCount = count || 0;
-  const initialHasMore = totalReviewCount > PAGE_SIZE;
+  const initialReviews = mapSupabaseReviewsToArray(reviewPage.reviews);
+  const totalReviewCount = currentCourseData.numReviews || initialReviews.length;
+  const initialHasMore = reviewPage.hasMore;
 
   // Breadcrumb data for structured data
   const breadcrumbs = [

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -85,6 +85,7 @@ export default function Error({ error, reset }: ErrorProps) {
             <Button
               component={Link}
               href="/"
+              prefetch={false}
               variant="outline"
               leftSection={<IconHome size={18} />}
               color="dark"

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import Script from 'next/script';
 import { Metadata, Viewport } from 'next';
 import { GoogleAnalytics } from '@next/third-parties/google';
 import { Analytics } from '@vercel/analytics/next';
@@ -103,8 +102,6 @@ export default function RootLayout({
         <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
         <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
         <link rel="manifest" href="/site.webmanifest" />
-        {/* Preload LCP image for home page */}
-        <link rel="preload" as="image" type="image/webp" href="/gt_quad.webp" fetchPriority="high" />
         <ColorSchemeScript defaultColorScheme="auto" />
         {/* WCAG-compliant dimmed color override */}
         <style dangerouslySetInnerHTML={{ __html: `
@@ -124,27 +121,10 @@ export default function RootLayout({
         <Providers>{children}</Providers>
         {process.env.VERCEL && <Analytics />}
         {process.env.VERCEL && <SpeedInsights />}
-        {/* Google Analytics */}
         {process.env.NEXT_PUBLIC_GA_ID && (
-          <>
-            <Script
-              src={`https://www.googletagmanager.com/gtag/js?id=${process.env.NEXT_PUBLIC_GA_ID}`}
-              strategy="afterInteractive"
-            />
-            <Script id="google-analytics" strategy="afterInteractive">
-              {`
-                window.dataLayer = window.dataLayer || [];
-                function gtag(){dataLayer.push(arguments);}
-                gtag('js', new Date());
-                gtag('config', '${process.env.NEXT_PUBLIC_GA_ID}');
-              `}
-            </Script>
-          </>
+          <GoogleAnalytics gaId={process.env.NEXT_PUBLIC_GA_ID} />
         )}
       </body>
-      {process.env.NEXT_PUBLIC_GA_ID && (
-        <GoogleAnalytics gaId={process.env.NEXT_PUBLIC_GA_ID} />
-      )}
     </html>
   );
 }

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -103,6 +103,7 @@ export default function NotFound() {
                 leftSection={<IconHome size={16} />}
                 component={Link}
                 href="/"
+                prefetch={false}
               >
                 Back to Home
               </Button>
@@ -120,6 +121,7 @@ export default function NotFound() {
                   size="xs"
                   component={Link}
                   href="/schedule"
+                  prefetch={false}
                 >
                   Course Schedule
                 </Button>

--- a/app/recents/_components/RecentsContent.tsx
+++ b/app/recents/_components/RecentsContent.tsx
@@ -44,18 +44,27 @@ export default function RecentsContent({
   const [offset, setOffset] = useState(initialReviews.length);
   const [searchQuery, setSearchQuery] = useState('');
   const [debouncedSearch] = useDebouncedValue(searchQuery, 300);
+  const effectiveSearch =
+    debouncedSearch.trim().length >= 2 ? debouncedSearch.trim() : '';
   const [isSearching, setIsSearching] = useState(false);
   const loaderRef = useRef<HTMLDivElement>(null);
 
   // Reset and search when debounced search changes
   useEffect(() => {
     const performSearch = async () => {
-      if (debouncedSearch === '' && reviews === initialReviews) return;
+      if (effectiveSearch === '') {
+        setReviews(initialReviews);
+        setHasMore(initialHasMore);
+        setOffset(initialReviews.length);
+        return;
+      }
 
       setIsSearching(true);
       setLoading(true);
       try {
-        const searchParam = debouncedSearch ? `&search=${encodeURIComponent(debouncedSearch)}` : '';
+        const searchParam = effectiveSearch
+          ? `&search=${encodeURIComponent(effectiveSearch)}`
+          : '';
         const response = await fetch(`/api/reviews/recent?limit=${PAGE_SIZE}&offset=0${searchParam}`);
         if (!response.ok) throw new Error('Failed to fetch');
 
@@ -74,14 +83,16 @@ export default function RecentsContent({
     };
 
     performSearch();
-  }, [debouncedSearch]);
+  }, [effectiveSearch, initialHasMore, initialReviews]);
 
   const loadMore = useCallback(async () => {
     if (loading || !hasMore) return;
 
     setLoading(true);
     try {
-      const searchParam = debouncedSearch ? `&search=${encodeURIComponent(debouncedSearch)}` : '';
+      const searchParam = effectiveSearch
+        ? `&search=${encodeURIComponent(effectiveSearch)}`
+        : '';
       const response = await fetch(`/api/reviews/recent?limit=${PAGE_SIZE}&offset=${offset}${searchParam}`);
       if (!response.ok) throw new Error('Failed to fetch');
 
@@ -96,7 +107,7 @@ export default function RecentsContent({
     } finally {
       setLoading(false);
     }
-  }, [loading, hasMore, offset, debouncedSearch]);
+  }, [loading, hasMore, offset, effectiveSearch]);
 
   // Intersection Observer for infinite scroll
   useEffect(() => {
@@ -173,9 +184,9 @@ export default function RecentsContent({
             onChange={(e) => setSearchQuery(e.currentTarget.value)}
             aria-label="Search reviews"
           />
-          {debouncedSearch && (
+          {effectiveSearch && (
             <Text size="sm" c="grayMatter" mt="xs">
-              {reviews.length} result{reviews.length !== 1 ? 's' : ''} for "{debouncedSearch}"
+              {reviews.length} result{reviews.length !== 1 ? 's' : ''} for "{effectiveSearch}"
             </Text>
           )}
         </Paper>
@@ -205,7 +216,7 @@ export default function RecentsContent({
                   })}
                 </Text>
               </Group>
-              <ReviewCard {...review} searchHighlight={debouncedSearch} />
+              <ReviewCard {...review} searchHighlight={effectiveSearch} />
             </Box>
           ))}
         </Stack>

--- a/app/recents/page.tsx
+++ b/app/recents/page.tsx
@@ -1,56 +1,32 @@
-import { createClient } from '@/lib/supabase/server';
 import { getCoursesDataStatic } from '@/lib/staticData';
-import { Review, TCourseId } from '@/lib/types';
 import RecentsContent from './_components/RecentsContent';
-import type { Database } from '@/lib/supabase/database.types';
-
-type SupabaseReview = Database['public']['Tables']['reviews']['Row'];
+import { mapSupabaseReviewsToArray } from '@/lib/supabase/mappers';
+import {
+  EMPTY_PUBLIC_REVIEW_PAGE,
+  getPublicReviewsPage,
+} from '@/lib/supabase/publicReviews';
 
 const PAGE_SIZE = 20;
 
-// Convert Supabase reviews to Review format
-function mapSupabaseReviewsToReviews(reviews: SupabaseReview[]): Review[] {
-  return reviews.map((review) => ({
-    reviewId: review.id,
-    courseId: review.course_id as TCourseId,
-    year: review.year,
-    semesterId: review.semester as 'sp' | 'sm' | 'fa',
-    isLegacy: review.is_legacy,
-    reviewerId: review.reviewer_id ?? '',
-    isGTVerifiedReviewer: review.is_gt_verified,
-    created: new Date(review.created_at).getTime(),
-    modified: review.modified_at ? new Date(review.modified_at).getTime() : null,
-    body: review.body ?? '',
-    upvotes: review.upvotes,
-    downvotes: review.downvotes,
-    workload: review.workload ?? 0,
-    difficulty: (review.difficulty ?? 3) as 1 | 2 | 3 | 4 | 5,
-    overall: (review.overall ?? 3) as 1 | 2 | 3 | 4 | 5,
-    staffSupport: review.staff_support as 1 | 2 | 3 | 4 | 5 | undefined,
-  }));
-}
+// Route segment config must remain a statically analyzable literal for Next.js.
+export const revalidate = 21600;
 
 export default async function RecentsPage() {
-  const supabase = await createClient();
-
-  // Fetch initial page of reviews with count
-  const [{ data: reviews, count }, coursesDataStatic] = await Promise.all([
-    supabase
-      .from('reviews')
-      .select('*', { count: 'exact' })
-      .order('created_at', { ascending: false })
-      .range(0, PAGE_SIZE - 1),
+  const [reviewPage, coursesDataStatic] = await Promise.all([
+    getPublicReviewsPage({ limit: PAGE_SIZE }).catch((error) => {
+      console.error('Unable to load recent public reviews:', error);
+      return EMPTY_PUBLIC_REVIEW_PAGE;
+    }),
     getCoursesDataStatic(),
   ]);
 
-  const initialReviews = mapSupabaseReviewsToReviews(reviews || []);
-  const initialHasMore = (count || 0) > PAGE_SIZE;
+  const initialReviews = mapSupabaseReviewsToArray(reviewPage.reviews);
 
   return (
     <RecentsContent
       initialReviews={initialReviews}
       coursesDataStatic={coursesDataStatic}
-      initialHasMore={initialHasMore}
+      initialHasMore={reviewPage.hasMore}
     />
   );
 }

--- a/app/user/reviews/page.tsx
+++ b/app/user/reviews/page.tsx
@@ -22,8 +22,8 @@ import { IconPencil } from '@tabler/icons-react';
 import { GT_COLORS } from '@/lib/theme';
 
 // API function to interact with Supabase via API routes
-async function getUserReviewsFromApi(userId: string): Promise<TUserReviews> {
-  const response = await fetch(`/api/user/reviews?userId=${userId}`);
+async function getUserReviewsFromApi(): Promise<TUserReviews> {
+  const response = await fetch('/api/user/reviews');
   if (!response.ok) {
     throw new Error('Failed to fetch user reviews');
   }
@@ -35,12 +35,13 @@ export default function UserReviewsPage() {
   const authContext = useAuth();
   const [userReviews, setUserReviews] = useState<TUserReviews>({});
   const user = authContext?.user;
+  const userId = user?.id;
 
   useEffect(() => {
     async function fetchUserData() {
-      if (user?.id) {
+      if (userId) {
         try {
-          const reviews = await getUserReviewsFromApi(user.id);
+          const reviews = await getUserReviewsFromApi();
           setUserReviews(reviews);
         } catch (error) {
           console.error('Error fetching user data:', error);
@@ -53,7 +54,7 @@ export default function UserReviewsPage() {
       }
     }
     fetchUserData();
-  }, [user]);
+  }, [userId]);
 
   const reviewCount = Object.keys(userReviews)?.length || 0;
 

--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -27,9 +27,8 @@ module.exports = {
     if (path.startsWith('/course/') && path !== '/course') {
       return {
         loc: path,
-        changefreq: 'daily',
+        changefreq: 'weekly',
         priority: 0.9,
-        lastmod: new Date().toISOString(),
       };
     }
 
@@ -73,9 +72,8 @@ module.exports = {
       for (const courseId of Object.keys(courses)) {
         result.push({
           loc: `/course/${courseId}`,
-          changefreq: 'daily',
+          changefreq: 'weekly',
           priority: 0.9,
-          lastmod: new Date().toISOString(),
         });
       }
     } catch (error) {

--- a/next.config.js
+++ b/next.config.js
@@ -73,8 +73,9 @@ module.exports = {
       '@tabler/icons-react',
       '@supabase/supabase-js',
     ],
-    // Inline CSS into HTML for better Clarity session replay support
-    inlineCss: true,
+    // Keep CSS in immutable shared chunks so navigating between course pages
+    // does not resend the full stylesheet with every HTML response.
+    inlineCss: false,
   },
 
   // Reduce unused JavaScript with tree shaking

--- a/src/components/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs.tsx
@@ -47,6 +47,7 @@ export default function Breadcrumbs({ items, showHome = true }: BreadcrumbsProps
                 key={item.label}
                 component={Link}
                 href={item.href || '/'}
+                prefetch={false}
                 size="sm"
                 c="boldBlue"
                 style={{ display: 'flex', alignItems: 'center', gap: 4 }}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -170,6 +170,7 @@ export default function Footer() {
                     key={link.label}
                     component={Link}
                     href={link.href}
+                    prefetch={false}
                     size="sm"
                     c="white"
                     style={{

--- a/src/components/NavBarMantine.tsx
+++ b/src/components/NavBarMantine.tsx
@@ -97,7 +97,7 @@ export function NavBarMantine() {
         <Group h={64} justify="space-between">
           {/* Logo and Nav Links */}
           <Group gap="xl">
-            <Link href="/" style={{ textDecoration: 'none' }}>
+            <Link href="/" prefetch={false} style={{ textDecoration: 'none' }}>
               <Group gap="xs">
                 <ThemeIcon
                   size={36}
@@ -120,6 +120,7 @@ export function NavBarMantine() {
                   key={link.href}
                   component={Link}
                   href={link.href}
+                  prefetch={false}
                   variant="subtle"
                   size="sm"
                   fw={500}
@@ -335,6 +336,7 @@ export function NavBarMantine() {
                         leftSection={<IconFileText size={16} />}
                         component={Link}
                         href="/user/reviews"
+                        prefetch={false}
                       >
                         My Reviews
                       </Menu.Item>
@@ -416,6 +418,7 @@ export function NavBarMantine() {
               key={link.href}
               component={Link}
               href={link.href}
+              prefetch={false}
               variant="subtle"
               color="gray"
               fullWidth
@@ -581,6 +584,7 @@ export function NavBarMantine() {
               <Button
                 component={Link}
                 href="/user/reviews"
+                prefetch={false}
                 variant="light"
                 leftSection={<IconFileText size={18} />}
                 fullWidth

--- a/src/components/ReviewCard.tsx
+++ b/src/components/ReviewCard.tsx
@@ -8,11 +8,8 @@ import {
   IconTrash,
   IconPencil,
 } from '@tabler/icons-react';
-import stringWidth from 'string-width';
 import remarkGfm from 'remark-gfm';
-import rehypeKatex from 'rehype-katex';
 import rehypeRaw from 'rehype-raw';
-import remarkMath from 'remark-math';
 import {
   Box,
   Button,
@@ -31,11 +28,15 @@ import { useDisclosure } from '@mantine/hooks';
 
 import { mapSemesterIdToName } from '@/utilities';
 import { GT_COLORS, CSS_STAT_COLORS } from '@/lib/theme';
-import { toBlob } from 'html-to-image';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import Markdown from 'react-markdown';
-import ReviewForm from '@/components/ReviewForm';
+import dynamic from 'next/dynamic';
 import HighlightedText from '@/components/HighlightedText';
+
+const ReviewForm = dynamic(() => import('@/components/ReviewForm'), {
+  ssr: false,
+  loading: () => <Loader size="sm" />,
+});
 
 interface ReviewCardProps extends Review {
   courseName?: string;
@@ -96,6 +97,7 @@ export const copyReviewScreenshot = async (
 ) => {
   if (!element) return 'missing-element' as const;
   try {
+    const { toBlob } = await import('html-to-image');
     const blob = await toBlob(element, {
       skipFonts: true,
     });
@@ -376,15 +378,8 @@ const ReviewCard = ({
               [data-mantine-color-scheme="dark"] .review-body a:hover { color: #79c0ff; }
             `}</style>
             <Markdown
-              remarkPlugins={[
-                [
-                  remarkGfm,
-                  { singleTilde: false },
-                  { stringLength: stringWidth },
-                ],
-                remarkMath,
-              ]}
-              rehypePlugins={[rehypeKatex, rehypeRaw]}
+              remarkPlugins={[[remarkGfm, { singleTilde: false }]]}
+              rehypePlugins={[rehypeRaw]}
             >
               {body}
             </Markdown>
@@ -429,12 +424,14 @@ const ReviewCard = ({
         centered
         size="lg"
       >
-        <ReviewForm
-          courseId={courseId}
-          courseName={courseName as TCourseName}
-          reviewInput={reviewInputMemo}
-          handleReviewModalClose={closeEditModal}
-        />
+        {editModalOpened && (
+          <ReviewForm
+            courseId={courseId}
+            courseName={courseName as TCourseName}
+            reviewInput={reviewInputMemo}
+            handleReviewModalClose={closeEditModal}
+          />
+        )}
       </Modal>
     </div>
   );

--- a/src/components/ReviewForm.tsx
+++ b/src/components/ReviewForm.tsx
@@ -194,9 +194,9 @@ export const submitReviewAndNotify = async (
   }
 };
 
-export const fetchUserReviews = async (userId: string): Promise<TUserReviews> => {
+export const fetchUserReviews = async (_userId?: string): Promise<TUserReviews> => {
   try {
-    const response = await fetch(`/api/user/reviews?userId=${userId}`);
+    const response = await fetch('/api/user/reviews');
     if (response.ok) {
       return await response.json();
     }
@@ -204,6 +204,18 @@ export const fetchUserReviews = async (userId: string): Promise<TUserReviews> =>
   } catch (error) {
     console.error('Error fetching user reviews:', error);
     return {};
+  }
+};
+
+export const fetchUserReviewKeys = async (): Promise<string[]> => {
+  try {
+    const response = await fetch('/api/user/reviews?summary=true');
+    if (!response.ok) return [];
+    const data = await response.json();
+    return Array.isArray(data.reviewKeys) ? data.reviewKeys : [];
+  } catch (error) {
+    console.error('Error fetching user review summary:', error);
+    return [];
   }
 };
 
@@ -215,7 +227,7 @@ const ReviewForm = ({
   const authContext = useAuth();
   const user = authContext?.user;
 
-  const [userReviews, setUserReviews] = useState<TUserReviews>({});
+  const [userReviewKeys, setUserReviewKeys] = useState<string[]>([]);
 
   const yearRange = getYearRange();
 
@@ -258,7 +270,7 @@ const ReviewForm = ({
   useEffect(() => {
     if (!userId) return;
 
-    fetchUserReviews(userId).then(setUserReviews);
+    fetchUserReviewKeys().then(setUserReviewKeys);
   }, [userId]);
 
   // Only reset form when reviewId changes (editing a different review)
@@ -334,7 +346,7 @@ const ReviewForm = ({
                     },
                     validateNotTakenCourse: (semester) => {
                       return validateUserNotTakenCourse(
-                        userReviews,
+                        userReviewKeys,
                         courseId,
                         semester,
                         getValues()?.year
@@ -380,7 +392,7 @@ const ReviewForm = ({
                     },
                     validateNotTakenCourse: (year) => {
                       return validateUserNotTakenCourse(
-                        userReviews,
+                        userReviewKeys,
                         courseId,
                         getValues()?.semesterId,
                         year
@@ -654,14 +666,17 @@ export const validateSemesterYear = (
 };
 
 export const validateUserNotTakenCourse = (
-  userReviews: TUserReviews | Record<string, never>,
+  userReviews: TUserReviews | Record<string, never> | string[],
   courseId: TCourseId,
   semester: TNullable<string>,
   year: TNullable<number>
 ) => {
   if (semester && year) {
     const objKey = `${courseId}-${year}-${mapSemsterIdToTerm[semester]}`;
-    return Object.keys(userReviews).find((key) => key.includes(objKey))
+    const reviewKeys = Array.isArray(userReviews)
+      ? userReviews
+      : Object.keys(userReviews);
+    return reviewKeys.find((key) => key.includes(objKey))
       ? false
       : true;
   }

--- a/src/components/providers/Providers.tsx
+++ b/src/components/providers/Providers.tsx
@@ -24,6 +24,8 @@ const LoginDrawer = dynamic(loadLoginDrawer, {
 
 function LoginDrawerWrapper() {
   const { loginOpen, handleLoginClose } = useMenu();
+  if (!loginOpen) return null;
+
   return (
     <Suspense fallback={null}>
       <LoginDrawer opened={loginOpen} onClose={handleLoginClose} />

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,7 +1,11 @@
 'use client';
 
 import { createContext, useContext, useEffect, useState, useRef } from 'react';
-import { getClient, hasSupabaseBrowserConfig } from '@/lib/supabase/client';
+import {
+  getClient,
+  hasSupabaseBrowserConfig,
+  SUPABASE_RESTRICTED_EVENT,
+} from '@/lib/supabase/client';
 import { useRouter } from 'next/navigation';
 import { notifySuccess, notifyError } from '@/utils/notifications';
 import type { User, Session } from '@supabase/supabase-js';
@@ -80,6 +84,19 @@ export const AuthProvider = ({ children }: TContextProviderProps) => {
       return;
     }
 
+    const handleSupabaseRestriction = () => {
+      supabase.auth.stopAutoRefresh();
+      setSession(null);
+      setUser(null);
+      previousUserRef.current = null;
+      setLoading(false);
+    };
+
+    window.addEventListener(
+      SUPABASE_RESTRICTED_EVENT,
+      handleSupabaseRestriction
+    );
+
     // Get initial session. If local auth state is corrupt/stale, fail closed
     // to anonymous and ask the server cleanup route to expire any leftover
     // Supabase cookies rather than leaving the app permanently "loading".
@@ -147,7 +164,13 @@ export const AuthProvider = ({ children }: TContextProviderProps) => {
       }
     });
 
-    return () => subscription.unsubscribe();
+    return () => {
+      window.removeEventListener(
+        SUPABASE_RESTRICTED_EVENT,
+        handleSupabaseRestriction
+      );
+      subscription.unsubscribe();
+    };
   }, []); // Empty dependency array - subscription should only be created once
 
   const signInWithProvider = async (

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -1,0 +1,38 @@
+import {
+  clearSupabaseAuthStorage,
+  isSupabaseRefreshTokenRequest,
+  makeRefreshRateLimitTerminal,
+  shouldOpenSupabaseAuthCircuit,
+  SUPABASE_AUTH_CIRCUIT_EVENT,
+} from '@/lib/supabase/authCircuitBreaker';
+
+const circuitBreakerFlag = '__omshubSupabaseAuthCircuitInstalled';
+const instrumentedWindow = window as typeof window & {
+  [circuitBreakerFlag]?: boolean;
+};
+
+if (!instrumentedWindow[circuitBreakerFlag]) {
+  instrumentedWindow[circuitBreakerFlag] = true;
+  const originalFetch = window.fetch.bind(window);
+
+  window.fetch = async (input, init) => {
+    const response = await originalFetch(input, init);
+
+    if (shouldOpenSupabaseAuthCircuit(input, response.status)) {
+      clearSupabaseAuthStorage();
+      window.dispatchEvent(new Event(SUPABASE_AUTH_CIRCUIT_EVENT));
+    }
+
+    // Supabase auth-js retries refresh-token 429s within the same refresh tick.
+    // Returning a terminal 400 only for this internal request ends that retry;
+    // the real 429 has already been observed above and the stale session cleared.
+    if (
+      response.status === 429 &&
+      isSupabaseRefreshTokenRequest(input)
+    ) {
+      return makeRefreshRateLimitTerminal(response);
+    }
+
+    return response;
+  };
+}

--- a/src/lib/cacheHeaders.ts
+++ b/src/lib/cacheHeaders.ts
@@ -1,13 +1,25 @@
 import { NextResponse } from 'next/server';
 
+// Let browsers absorb quick repeat visits while Vercel serves shared responses
+// from its CDN. This reduces Function invocations without creating a long-lived
+// stale browser cache.
 export const PUBLIC_API_CACHE_CONTROL =
-  'public, s-maxage=300, stale-while-revalidate=3600';
+  'public, max-age=120, stale-while-revalidate=300';
+export const VERCEL_PUBLIC_API_CACHE_CONTROL =
+  'public, s-maxage=900, stale-while-revalidate=21600';
 
-export function publicApiJson<T>(
-  body: T,
-  init?: ResponseInit
-): NextResponse<T> {
+export function publicApiJson<T>(body: T, init?: { status?: number }) {
   const response = NextResponse.json(body, init);
   response.headers.set('Cache-Control', PUBLIC_API_CACHE_CONTROL);
+  response.headers.set(
+    'Vercel-CDN-Cache-Control',
+    VERCEL_PUBLIC_API_CACHE_CONTROL
+  );
+  return response;
+}
+
+export function uncachedApiJson<T>(body: T, init?: { status?: number }) {
+  const response = NextResponse.json(body, init);
+  response.headers.set('Cache-Control', 'private, no-store');
   return response;
 }

--- a/src/lib/supabase/__tests__/auth.test.ts
+++ b/src/lib/supabase/__tests__/auth.test.ts
@@ -1,0 +1,36 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { getAuthenticatedClaims } from '../auth';
+import type { Database } from '../database.types';
+
+function mockClient(result: unknown) {
+  return {
+    auth: {
+      getClaims: jest.fn().mockResolvedValue(result),
+    },
+  } as unknown as SupabaseClient<Database>;
+}
+
+describe('getAuthenticatedClaims()', () => {
+  it('returns the verified user id and email', async () => {
+    const result = await getAuthenticatedClaims(
+      mockClient({
+        data: { claims: { sub: 'user-123', email: 'student@gatech.edu' } },
+        error: null,
+      })
+    );
+
+    expect(result).toEqual({
+      userId: 'user-123',
+      email: 'student@gatech.edu',
+    });
+  });
+
+  it('rejects errors and claims without a subject', async () => {
+    await expect(
+      getAuthenticatedClaims(mockClient({ data: null, error: new Error('bad token') }))
+    ).resolves.toBeNull();
+    await expect(
+      getAuthenticatedClaims(mockClient({ data: { claims: {} }, error: null }))
+    ).resolves.toBeNull();
+  });
+});

--- a/src/lib/supabase/__tests__/client.test.ts
+++ b/src/lib/supabase/__tests__/client.test.ts
@@ -30,7 +30,10 @@ describe('createClient()', () => {
     expect(mockCreateBrowserClient).toHaveBeenCalledWith(
       'https://example.supabase.co',
       'publishable-key',
-      { cookieOptions: { domain: undefined } }
+      {
+        cookieOptions: { domain: undefined },
+        global: { fetch: expect.any(Function) },
+      }
     );
   });
 

--- a/src/lib/supabase/__tests__/proxy.test.ts
+++ b/src/lib/supabase/__tests__/proxy.test.ts
@@ -1,21 +1,25 @@
 import { updateSession } from '../proxy';
 import { createServerClient } from '@supabase/ssr';
 
-const mockGetUser = jest.fn().mockResolvedValue({ data: { user: null }, error: null });
+const mockGetClaims = jest.fn().mockResolvedValue({ data: { user: null }, error: null });
 
 jest.mock('@supabase/ssr', () => ({
   createServerClient: jest.fn((_url, _key, options) => ({
     auth: {
-      getUser: mockGetUser,
+      getClaims: mockGetClaims,
     },
     __options: options,
   })),
 }));
 
 const mockNextResponseCookies = { set: jest.fn() };
+const mockNextResponseHeaders = { set: jest.fn() };
 jest.mock('next/server', () => ({
   NextResponse: {
-    next: jest.fn(() => ({ cookies: mockNextResponseCookies })),
+    next: jest.fn(() => ({
+      cookies: mockNextResponseCookies,
+      headers: mockNextResponseHeaders,
+    })),
   },
 }));
 
@@ -56,7 +60,7 @@ describe('updateSession()', () => {
       NEXT_PUBLIC_SUPABASE_URL: 'https://example.supabase.co',
       NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: 'publishable-key',
     };
-    mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+    mockGetClaims.mockResolvedValue({ data: { user: null }, error: null });
   });
 
   afterAll(() => {
@@ -69,26 +73,26 @@ describe('updateSession()', () => {
     await expect(updateSession(makeMockRequest())).resolves.toBeDefined();
 
     expect(createServerClient).not.toHaveBeenCalled();
-    expect(mockGetUser).not.toHaveBeenCalled();
+    expect(mockGetClaims).not.toHaveBeenCalled();
   });
 
-  it('does NOT call getUser() when no session cookie is present', async () => {
+  it('does NOT call getClaims() when no session cookie is present', async () => {
     await updateSession(makeMockRequest());
-    expect(mockGetUser).not.toHaveBeenCalled();
+    expect(mockGetClaims).not.toHaveBeenCalled();
   });
 
-  it('does NOT call getUser() for PKCE code_verifier cookies only', async () => {
+  it('does NOT call getClaims() for PKCE code_verifier cookies only', async () => {
     await updateSession(
       makeMockRequest([{ name: 'sb-abc123-auth-token-code-verifier', value: 'verifier' }])
     );
-    expect(mockGetUser).not.toHaveBeenCalled();
+    expect(mockGetClaims).not.toHaveBeenCalled();
   });
 
-  it('calls getUser() when a session token cookie is present', async () => {
+  it('calls getClaims() when a session token cookie is present', async () => {
     await updateSession(
       makeMockRequest([{ name: 'sb-abc123-auth-token', value: 'token' }])
     );
-    expect(mockGetUser).toHaveBeenCalledTimes(1);
+    expect(mockGetClaims).toHaveBeenCalledTimes(1);
   });
 
   it('applies Supabase cookie writes to the request and response', async () => {
@@ -111,33 +115,33 @@ describe('updateSession()', () => {
     );
   });
 
-  it('calls getUser() for chunked session token cookies', async () => {
+  it('calls getClaims() for chunked session token cookies', async () => {
     await updateSession(
       makeMockRequest([{ name: 'sb-abc123-auth-token.0', value: 'chunk' }])
     );
-    expect(mockGetUser).toHaveBeenCalledTimes(1);
+    expect(mockGetClaims).toHaveBeenCalledTimes(1);
   });
 
-  it('calls getUser() for API requests with session cookies so stale cookies are cleared before handlers run', async () => {
+  it('calls getClaims() for API requests with session cookies so stale cookies are cleared before handlers run', async () => {
     await updateSession(
       makeMockRequest([{ name: 'sb-abc123-auth-token', value: 'token' }], {
         pathname: '/api/reviews',
       })
     );
-    expect(mockGetUser).toHaveBeenCalledTimes(1);
+    expect(mockGetClaims).toHaveBeenCalledTimes(1);
   });
 
-  it('calls getUser() for Next.js prefetch requests with session cookies so Server Components receive refreshed cookies', async () => {
+  it('calls getClaims() for Next.js prefetch requests with session cookies so Server Components receive refreshed cookies', async () => {
     await updateSession(
       makeMockRequest([{ name: 'sb-abc123-auth-token', value: 'token' }], {
         headers: { 'next-router-prefetch': '1' },
       })
     );
-    expect(mockGetUser).toHaveBeenCalledTimes(1);
+    expect(mockGetClaims).toHaveBeenCalledTimes(1);
   });
 
-  it('clears auth-token cookies when getUser() reports an invalid refresh token', async () => {
-    mockGetUser.mockResolvedValueOnce({
+  it('clears auth-token cookies when getClaims() reports an invalid refresh token', async () => {
+    mockGetClaims.mockResolvedValueOnce({
       data: { user: null },
       error: { message: 'Invalid Refresh Token: Refresh Token Not Found', status: 400 },
     });
@@ -167,8 +171,8 @@ describe('updateSession()', () => {
     );
   });
 
-  it('does not clear auth-token cookies when getUser() is rate limited', async () => {
-    mockGetUser.mockResolvedValueOnce({
+  it('does not clear auth-token cookies when getClaims() is rate limited', async () => {
+    mockGetClaims.mockResolvedValueOnce({
       data: { user: null },
       error: { message: 'Too many requests', status: 429 },
     });
@@ -184,8 +188,8 @@ describe('updateSession()', () => {
     );
   });
 
-  it('does not clear auth-token cookies when getUser returns an error without a message', async () => {
-    mockGetUser.mockResolvedValueOnce({
+  it('does not clear auth-token cookies when getClaims returns an error without a message', async () => {
+    mockGetClaims.mockResolvedValueOnce({
       data: { user: null },
       error: { status: 500 },
     });
@@ -202,7 +206,7 @@ describe('updateSession()', () => {
   });
 
   it('also clears production domain auth-token cookies for www/apex hosts', async () => {
-    mockGetUser.mockResolvedValueOnce({
+    mockGetClaims.mockResolvedValueOnce({
       data: { user: null },
       error: { message: 'Invalid Refresh Token: Refresh Token Not Found', status: 400 },
     });
@@ -221,7 +225,7 @@ describe('updateSession()', () => {
   });
 
   it('treats production host casing case-insensitively when clearing domain cookies', async () => {
-    mockGetUser.mockResolvedValueOnce({
+    mockGetClaims.mockResolvedValueOnce({
       data: { user: null },
       error: { message: 'Invalid Refresh Token: Refresh Token Not Found', status: 400 },
     });
@@ -240,7 +244,7 @@ describe('updateSession()', () => {
   });
 
   it('uses forwarded production hosts when clearing domain auth-token cookies', async () => {
-    mockGetUser.mockResolvedValueOnce({
+    mockGetClaims.mockResolvedValueOnce({
       data: { user: null },
       error: { message: 'Invalid Refresh Token: Refresh Token Not Found', status: 400 },
     });
@@ -260,7 +264,7 @@ describe('updateSession()', () => {
   });
 
   it('handles comma-separated forwarded hosts when clearing domain cookies', async () => {
-    mockGetUser.mockResolvedValueOnce({
+    mockGetClaims.mockResolvedValueOnce({
       data: { user: null },
       error: { message: 'refresh token not found', status: 400 },
     });
@@ -279,7 +283,7 @@ describe('updateSession()', () => {
   });
 
   it('does not let thrown auth refresh failures break public requests', async () => {
-    mockGetUser.mockRejectedValueOnce({
+    mockGetClaims.mockRejectedValueOnce({
       message: 'Invalid Refresh Token: Refresh Token Not Found',
       status: 400,
     });
@@ -298,7 +302,7 @@ describe('updateSession()', () => {
   });
 
   it('rethrows unexpected auth refresh failures', async () => {
-    mockGetUser.mockRejectedValueOnce(new Error('network unavailable'));
+    mockGetClaims.mockRejectedValueOnce(new Error('network unavailable'));
 
     await expect(
       updateSession(

--- a/src/lib/supabase/auth.ts
+++ b/src/lib/supabase/auth.ts
@@ -1,0 +1,29 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { Database } from './database.types';
+
+type AuthenticatedClaims = {
+  userId: string;
+  email?: string;
+};
+
+/**
+ * Verify the current access token without a per-request Auth API call.
+ *
+ * OMSHub uses an asymmetric Supabase signing key, so getClaims() verifies the
+ * token against the cached JWKS instead of calling /auth/v1/user like
+ * getUser(). Database RLS remains the final authorization boundary.
+ */
+export async function getAuthenticatedClaims(
+  supabase: SupabaseClient<Database>
+): Promise<AuthenticatedClaims | null> {
+  const { data, error } = await supabase.auth.getClaims();
+  const userId = data?.claims?.sub;
+
+  if (error || typeof userId !== 'string' || !userId) return null;
+
+  const email = data.claims.email;
+  return {
+    userId,
+    ...(typeof email === 'string' ? { email } : {}),
+  };
+}

--- a/src/lib/supabase/authCircuitBreaker.ts
+++ b/src/lib/supabase/authCircuitBreaker.ts
@@ -1,0 +1,89 @@
+export const SUPABASE_AUTH_CIRCUIT_EVENT = 'omshub:supabase-restricted';
+
+function getRequestUrl(input: RequestInfo | URL) {
+  if (typeof input === 'string') return input;
+  if (input instanceof URL) return input.href;
+  return input.url;
+}
+
+function isSupabaseRequest(input: RequestInfo | URL) {
+  try {
+    return new URL(getRequestUrl(input)).hostname.endsWith('.supabase.co');
+  } catch {
+    return false;
+  }
+}
+
+export function isSupabaseRefreshTokenRequest(input: RequestInfo | URL) {
+  try {
+    const url = new URL(getRequestUrl(input));
+    return (
+      url.hostname.endsWith('.supabase.co') &&
+      url.pathname.endsWith('/auth/v1/token') &&
+      url.searchParams.get('grant_type') === 'refresh_token'
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function shouldOpenSupabaseAuthCircuit(
+  input: RequestInfo | URL,
+  status: number
+) {
+  if (status === 402) return isSupabaseRequest(input);
+  return (
+    isSupabaseRefreshTokenRequest(input) &&
+    [400, 401, 403, 429].includes(status)
+  );
+}
+
+export function getSupabaseAuthStorageKey(
+  supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+) {
+  if (!supabaseUrl) return null;
+
+  try {
+    const projectRef = new URL(supabaseUrl).hostname.split('.')[0];
+    return projectRef ? `sb-${projectRef}-auth-token` : null;
+  } catch {
+    return null;
+  }
+}
+
+export function clearSupabaseAuthStorage() {
+  if (typeof window === 'undefined') return;
+
+  const storageKey = getSupabaseAuthStorageKey();
+  if (!storageKey) return;
+
+  // @supabase/ssr can split a session across several cookies. Remove the base
+  // cookie and every chunk so a stale single-use refresh token cannot restart
+  // the loop on reload or in another open tab.
+  document.cookie.split(';').forEach((cookie) => {
+    const name = cookie.split('=')[0]?.trim();
+    if (
+      name === storageKey ||
+      name?.startsWith(`${storageKey}.`) ||
+      name === `${storageKey}-code-verifier`
+    ) {
+      document.cookie = `${name}=; Max-Age=0; Path=/; SameSite=Lax`;
+    }
+  });
+
+  // Older client versions may have persisted the same session locally.
+  try {
+    window.localStorage.removeItem(storageKey);
+    window.localStorage.removeItem(`${storageKey}-code-verifier`);
+  } catch {
+    // Storage can be unavailable in privacy-restricted browser contexts.
+  }
+}
+
+export function makeRefreshRateLimitTerminal(response: Response) {
+  return new Response(response.body, {
+    status: 400,
+    statusText: 'Bad Request',
+    headers: response.headers,
+  });
+}

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -1,5 +1,18 @@
 import { createBrowserClient } from '@supabase/ssr';
 import type { Database } from './database.types';
+import { SUPABASE_AUTH_CIRCUIT_EVENT } from './authCircuitBreaker';
+
+export const SUPABASE_RESTRICTED_EVENT = SUPABASE_AUTH_CIRCUIT_EVENT;
+
+export const monitoredFetch: typeof fetch = async (input, init) => {
+  const response = await fetch(input, init);
+
+  if (response.status === 402 && typeof window !== 'undefined') {
+    window.dispatchEvent(new Event(SUPABASE_RESTRICTED_EVENT));
+  }
+
+  return response;
+};
 
 // Scope auth cookies (including PKCE code_verifier) to the registrable domain
 // so they survive www <-> apex navigations on the canonical production host.
@@ -44,7 +57,10 @@ export function createClient() {
   return createBrowserClient<Database>(
     config.url,
     config.publishableKey,
-    { cookieOptions: { domain: getCookieDomain() } }
+    {
+      cookieOptions: { domain: getCookieDomain() },
+      global: { fetch: monitoredFetch },
+    }
   );
 }
 

--- a/src/lib/supabase/mappers.ts
+++ b/src/lib/supabase/mappers.ts
@@ -1,4 +1,5 @@
 import type { Database } from './database.types';
+import type { PublicReviewRow } from './publicReviews';
 import type { Review, TCourseId, TProgrammingLanguageId } from '@/lib/types';
 
 export type SupabaseReview = Database['public']['Tables']['reviews']['Row'];
@@ -10,7 +11,9 @@ function nullToUndefined<T>(value: T | null): T | undefined {
 /**
  * Convert a single Supabase review row to the Review type used throughout the app
  */
-export function mapSupabaseReviewToReview(review: SupabaseReview): Review {
+export function mapSupabaseReviewToReview(
+  review: SupabaseReview | PublicReviewRow
+): Review {
   return {
     reviewId: review.id,
     courseId: review.course_id as TCourseId,
@@ -27,28 +30,34 @@ export function mapSupabaseReviewToReview(review: SupabaseReview): Review {
     workload: review.workload ?? 0,
     difficulty: (review.difficulty ?? 3) as 1 | 2 | 3 | 4 | 5,
     overall: (review.overall ?? 3) as 1 | 2 | 3 | 4 | 5,
-    staffSupport: review.staff_support as 1 | 2 | 3 | 4 | 5 | undefined,
-    isRecommended: nullToUndefined(review.is_recommended),
-    isGoodFirstCourse: nullToUndefined(review.is_good_first_course),
-    isPairable: nullToUndefined(review.is_pairable),
-    hasGroupProjects: nullToUndefined(review.has_group_projects),
-    hasWritingAssignments: nullToUndefined(review.has_writing_assignments),
-    hasExamsQuizzes: nullToUndefined(review.has_exams_quizzes),
-    hasMandatoryReadings: nullToUndefined(review.has_mandatory_readings),
-    hasProgrammingAssignments: nullToUndefined(review.has_programming_assignments),
-    hasProvidedDevEnv: nullToUndefined(review.has_provided_dev_env),
-    programmingLanguagesIds: review.programming_languages as TProgrammingLanguageId[] | undefined,
-    preparation: review.preparation as 1 | 2 | 3 | 4 | 5 | undefined,
-    omsCoursesTaken: review.oms_courses_taken,
-    hasRelevantWorkExperience: nullToUndefined(review.has_relevant_work_experience),
-    experienceLevelId: nullToUndefined(review.experience_level) as 'jr' | 'mid' | 'sr' | undefined,
-    gradeId: nullToUndefined(review.grade),
+    ...('staff_support' in review
+      ? {
+          staffSupport: review.staff_support as 1 | 2 | 3 | 4 | 5 | undefined,
+          isRecommended: nullToUndefined(review.is_recommended),
+          isGoodFirstCourse: nullToUndefined(review.is_good_first_course),
+          isPairable: nullToUndefined(review.is_pairable),
+          hasGroupProjects: nullToUndefined(review.has_group_projects),
+          hasWritingAssignments: nullToUndefined(review.has_writing_assignments),
+          hasExamsQuizzes: nullToUndefined(review.has_exams_quizzes),
+          hasMandatoryReadings: nullToUndefined(review.has_mandatory_readings),
+          hasProgrammingAssignments: nullToUndefined(review.has_programming_assignments),
+          hasProvidedDevEnv: nullToUndefined(review.has_provided_dev_env),
+          programmingLanguagesIds: review.programming_languages as TProgrammingLanguageId[] | undefined,
+          preparation: review.preparation as 1 | 2 | 3 | 4 | 5 | undefined,
+          omsCoursesTaken: review.oms_courses_taken,
+          hasRelevantWorkExperience: nullToUndefined(review.has_relevant_work_experience),
+          experienceLevelId: nullToUndefined(review.experience_level) as 'jr' | 'mid' | 'sr' | undefined,
+          gradeId: nullToUndefined(review.grade),
+        }
+      : {}),
   };
 }
 
 /**
  * Convert an array of Supabase review rows to Review array
  */
-export function mapSupabaseReviewsToArray(reviews: SupabaseReview[]): Review[] {
+export function mapSupabaseReviewsToArray(
+  reviews: Array<SupabaseReview | PublicReviewRow>
+): Review[] {
   return reviews.map(mapSupabaseReviewToReview);
 }

--- a/src/lib/supabase/proxy.ts
+++ b/src/lib/supabase/proxy.ts
@@ -57,6 +57,7 @@ export async function updateSession(request: NextRequest) {
 
   const supabaseConfig = getSupabaseProxyConfig();
   if (!supabaseConfig) {
+    supabaseResponse.headers.set('Cache-Control', 'private, no-store');
     return supabaseResponse;
   }
 
@@ -90,7 +91,7 @@ export async function updateSession(request: NextRequest) {
   const hasSession = request.cookies.getAll().some((c) => isAuthTokenCookie(c.name));
   if (hasSession) {
     try {
-      const { error } = await supabase.auth.getUser();
+      const { error } = await supabase.auth.getClaims();
       if (shouldClearAuthCookies(error)) {
         clearAuthTokenCookies(request, supabaseResponse);
       }
@@ -103,5 +104,6 @@ export async function updateSession(request: NextRequest) {
     }
   }
 
+  supabaseResponse.headers.set('Cache-Control', 'private, no-store');
   return supabaseResponse;
 }

--- a/src/lib/supabase/publicReviews.ts
+++ b/src/lib/supabase/publicReviews.ts
@@ -1,0 +1,168 @@
+import { createClient } from '@supabase/supabase-js';
+import type { Database } from './database.types';
+
+type ReviewRow = Database['public']['Tables']['reviews']['Row'];
+
+export type PublicReviewRow = Pick<
+  ReviewRow,
+  | 'id'
+  | 'course_id'
+  | 'reviewer_id'
+  | 'year'
+  | 'semester'
+  | 'body'
+  | 'workload'
+  | 'difficulty'
+  | 'overall'
+  | 'is_legacy'
+  | 'is_gt_verified'
+  | 'upvotes'
+  | 'downvotes'
+  | 'created_at'
+  | 'modified_at'
+>;
+
+export const PUBLIC_REVIEW_COLUMNS = [
+  'id',
+  'course_id',
+  'reviewer_id',
+  'year',
+  'semester',
+  'body',
+  'workload',
+  'difficulty',
+  'overall',
+  'is_legacy',
+  'is_gt_verified',
+  'upvotes',
+  'downvotes',
+  'created_at',
+  'modified_at',
+].join(',');
+
+export const PUBLIC_REVIEW_REVALIDATE_SECONDS = 21600;
+export const RECENT_REVIEWS_CACHE_TAG = 'reviews:recent';
+export const MAX_PUBLIC_REVIEW_LIMIT = 50;
+export const MAX_PUBLIC_REVIEW_OFFSET = 5000;
+export const MAX_PUBLIC_REVIEW_SEARCH_LENGTH = 100;
+const RESTRICTION_BACKOFF_MS = 5 * 60 * 1000;
+
+let restrictedUntil = 0;
+
+export function courseReviewsCacheTag(courseId: string) {
+  return `reviews:course:${courseId.trim().toUpperCase()}`;
+}
+
+export function normalizePublicReviewSearch(search?: string) {
+  return search?.trim().replace(/\s+/g, ' ').toLowerCase() || undefined;
+}
+
+export interface PublicReviewFilters {
+  courseId?: string;
+  year?: number;
+  semester?: string;
+  search?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export interface PublicReviewPage {
+  reviews: PublicReviewRow[];
+  hasMore: boolean;
+}
+
+export const EMPTY_PUBLIC_REVIEW_PAGE: PublicReviewPage = {
+  reviews: [],
+  hasMore: false,
+};
+
+export function toPublicReviewPage(
+  rows: PublicReviewRow[],
+  limit: number
+): PublicReviewPage {
+  return {
+    reviews: rows.slice(0, limit),
+    hasMore: rows.length > limit,
+  };
+}
+
+function createPublicReadClient(tags: string[]) {
+  const cachedFetch: typeof fetch = async (input, init) => {
+    if (Date.now() < restrictedUntil) {
+      throw new Error('Supabase public reads are temporarily restricted');
+    }
+
+    const response = await fetch(input, {
+      ...init,
+      next: {
+        revalidate: PUBLIC_REVIEW_REVALIDATE_SECONDS,
+        tags,
+      },
+    } as RequestInit & {
+      next: { revalidate: number; tags: string[] };
+    });
+
+    if (response.status === 402) {
+      restrictedUntil = Date.now() + RESTRICTION_BACKOFF_MS;
+    }
+
+    return response;
+  };
+
+  return createClient<Database>(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
+    {
+      auth: {
+        autoRefreshToken: false,
+        detectSessionInUrl: false,
+        persistSession: false,
+      },
+      global: { fetch: cachedFetch },
+    }
+  );
+}
+
+export async function getPublicReviewsPage({
+  courseId,
+  year,
+  semester,
+  search,
+  limit = 20,
+  offset = 0,
+}: PublicReviewFilters = {}): Promise<PublicReviewPage> {
+  const safeLimit = Math.min(Math.max(limit, 1), MAX_PUBLIC_REVIEW_LIMIT);
+  const safeOffset = Math.min(Math.max(offset, 0), MAX_PUBLIC_REVIEW_OFFSET);
+  const normalizedCourseId = courseId?.trim().toUpperCase() || undefined;
+  const normalizedSemester = semester?.trim().toLowerCase() || undefined;
+  const normalizedSearch = normalizePublicReviewSearch(search);
+  const tags = normalizedCourseId
+    ? [courseReviewsCacheTag(normalizedCourseId)]
+    : [RECENT_REVIEWS_CACHE_TAG];
+  const supabase = createPublicReadClient(tags);
+
+  let query = supabase
+    .from('reviews')
+    .select(PUBLIC_REVIEW_COLUMNS)
+    .order('created_at', { ascending: false });
+
+  if (normalizedCourseId) query = query.eq('course_id', normalizedCourseId);
+  if (year) query = query.eq('year', year);
+  if (normalizedSemester) query = query.eq('semester', normalizedSemester);
+  if (normalizedSearch) query = query.ilike('body', `%${normalizedSearch}%`);
+
+  // Request one extra row to determine hasMore without an exact COUNT query.
+  const { data, error } = await query.range(
+    safeOffset,
+    safeOffset + safeLimit
+  );
+
+  if (error) {
+    throw new Error(`Failed to fetch public reviews: ${error.message}`);
+  }
+
+  return toPublicReviewPage(
+    (data ?? []) as unknown as PublicReviewRow[],
+    safeLimit
+  );
+}

--- a/supabase/migrations/20260716011125_optimize_reviews_and_rls.sql
+++ b/supabase/migrations/20260716011125_optimize_reviews_and_rls.sql
@@ -1,0 +1,116 @@
+-- Keep extensions out of the Data API's exposed public schema.
+create schema if not exists extensions;
+create schema if not exists private;
+revoke all on schema private from public;
+
+do $$
+begin
+  if exists (
+    select 1
+    from pg_extension
+    where extname = 'postgres_fdw'
+      and extnamespace = 'public'::regnamespace
+  ) then
+    execute 'alter extension postgres_fdw set schema extensions';
+  end if;
+end
+$$;
+
+create extension if not exists pg_trgm with schema extensions;
+
+-- Match the site's most frequent filters and sort order. The trigram index
+-- prevents ILIKE '%term%' review searches from scanning every review body.
+create index if not exists idx_reviews_course_created_at
+  on public.reviews (course_id, created_at desc);
+create index if not exists idx_reviews_course_year_sem_created_at
+  on public.reviews (course_id, year, semester, created_at desc);
+create index if not exists idx_reviews_reviewer_created_at
+  on public.reviews (reviewer_id, created_at desc);
+create index if not exists idx_reviews_body_trgm
+  on public.reviews using gin (body extensions.gin_trgm_ops)
+  where body is not null;
+create index if not exists idx_user_mapping_supabase
+  on public.user_id_mapping (supabase_uid);
+
+-- Canonicalize policies from both the original migration and the current
+-- production names. Wrapping auth.uid() in SELECT evaluates it once per query
+-- instead of once per candidate row.
+drop policy if exists "Reviews are viewable by everyone" on public.reviews;
+drop policy if exists "Anyone can view reviews" on public.reviews;
+drop policy if exists "Users can create their own reviews" on public.reviews;
+drop policy if exists "Authenticated users can create reviews" on public.reviews;
+drop policy if exists "Users can update their own reviews" on public.reviews;
+drop policy if exists "Users can delete their own reviews" on public.reviews;
+
+create policy "Anyone can view reviews"
+  on public.reviews for select
+  to anon, authenticated
+  using (true);
+create policy "Authenticated users can create reviews"
+  on public.reviews for insert
+  to authenticated
+  with check ((select auth.uid()) = reviewer_id);
+create policy "Users can update their own reviews"
+  on public.reviews for update
+  to authenticated
+  using ((select auth.uid()) = reviewer_id)
+  with check ((select auth.uid()) = reviewer_id);
+create policy "Users can delete their own reviews"
+  on public.reviews for delete
+  to authenticated
+  using ((select auth.uid()) = reviewer_id);
+
+drop policy if exists "Users can view own profile" on public.users;
+drop policy if exists "Users can view their own data" on public.users;
+drop policy if exists "Users can insert own profile" on public.users;
+drop policy if exists "Users can insert their own data" on public.users;
+drop policy if exists "Users can update own profile" on public.users;
+drop policy if exists "Users can update their own data" on public.users;
+
+create policy "Users can view their own data"
+  on public.users for select
+  to authenticated
+  using ((select auth.uid()) = id);
+create policy "Users can insert their own data"
+  on public.users for insert
+  to authenticated
+  with check ((select auth.uid()) = id);
+create policy "Users can update their own data"
+  on public.users for update
+  to authenticated
+  using ((select auth.uid()) = id)
+  with check ((select auth.uid()) = id);
+
+drop policy if exists "User ID mapping is service role only"
+  on public.user_id_mapping;
+drop policy if exists "Users can view their own mapping"
+  on public.user_id_mapping;
+create policy "Users can view their own mapping"
+  on public.user_id_mapping for select
+  to authenticated
+  using ((select auth.uid()) = supabase_uid);
+
+-- Keep the security-definer trigger outside the Data API's exposed schemas.
+create or replace function private.handle_new_user()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  insert into public.users (id, has_gt_email)
+  values (new.id, coalesce(new.email, '') like '%@gatech.edu');
+  return new;
+end;
+$$;
+
+revoke all on function private.handle_new_user() from public;
+revoke all on function private.handle_new_user() from anon;
+revoke all on function private.handle_new_user() from authenticated;
+
+drop trigger if exists on_auth_user_created on auth.users;
+create trigger on_auth_user_created
+  after insert on auth.users
+  for each row execute function private.handle_new_user();
+
+drop function if exists public.handle_new_user();


### PR DESCRIPTION
## Summary

- cache public review reads for six hours with targeted invalidation after review mutations
- select only public review fields and replace exact counts with one-row lookahead pagination
- stop failed refresh-token loops and avoid per-request Auth API lookups where local claim verification is available
- keep private user responses uncached and derive ownership from verified claims
- disable avoidable route prefetching, remove duplicate/global resource loading, keep CSS in shared chunks, and lazy-load review-only tools
- add review query indexes, optimized RLS policies, and move the signup trigger function out of the exposed schema

## Why

The current traffic pattern combines broad review queries, repeated count queries, auth refresh failures, route prefetching, and assets that are loaded outside the routes that need them. Together these increase Supabase egress and Vercel transfer/request usage.

## Validation

- `pnpm check:ci`
- 43 test suites and 254 tests passed
- lint passed with one existing Microsoft Clarity warning
- production build passed

## Deployment note

The database migration passed on the Supabase preview branch and will be verified separately in production.