### PR TITLE
fix: avoid schedule semester flash

### DIFF
--- a/app/schedule/ScheduleContent.integration.test.ts
+++ b/app/schedule/ScheduleContent.integration.test.ts
@@ -16,4 +16,17 @@ describe('schedule content future semester probing', () => {
       /if \(!userSelectedSemesterRef\.current\) \{\s*setActiveSemester\(available\[0\]\);\s*\}/
     );
   });
+
+  it('does not render the calendar-current semester before discovery finishes', () => {
+    expect(source).toContain("const [activeSemester, setActiveSemester] = useState('');");
+    expect(source).toContain('if (!activeSemester) return;');
+    expect(source).toContain("isDiscoveringSemester ? 'Finding latest semester…' : undefined");
+    expect(source).toContain('disabled={isDiscoveringSemester}');
+  });
+
+  it('falls back to the calendar-current semester when no future data exists', () => {
+    expect(source).toMatch(
+      /else \{\s*setLatestAvailableSemester\(initialActiveSemester\);\s*if \(!userSelectedSemesterRef\.current\) \{\s*setActiveSemester\(initialActiveSemester\);\s*\}/
+    );
+  });
 });

--- a/app/schedule/_components/ScheduleContent.tsx
+++ b/app/schedule/_components/ScheduleContent.tsx
@@ -329,8 +329,9 @@ export default function ScheduleContent() {
   const pastSemesters = useMemo(() => getPastSemesters(), []);
   const initialActiveSemester = getInitialActiveSemester(pastSemesters);
   const [semesters, setSemesters] = useState(pastSemesters);
-  const [activeSemester, setActiveSemester] = useState(initialActiveSemester);
-  const [latestAvailableSemester, setLatestAvailableSemester] = useState(initialActiveSemester);
+  const [activeSemester, setActiveSemester] = useState('');
+  const [latestAvailableSemester, setLatestAvailableSemester] = useState('');
+  const [isDiscoveringSemester, setIsDiscoveringSemester] = useState(true);
   const [searchQuery, setSearchQuery] = useState('');
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -365,7 +366,13 @@ export default function ScheduleContent() {
         }
       } else {
         setLatestAvailableSemester(initialActiveSemester);
+
+        if (!userSelectedSemesterRef.current) {
+          setActiveSemester(initialActiveSemester);
+        }
       }
+
+      setIsDiscoveringSemester(false);
     }
 
     probeFutureSemesters();
@@ -376,6 +383,8 @@ export default function ScheduleContent() {
   }, [initialActiveSemester, pastSemesters]);
 
   useEffect(() => {
+    if (!activeSemester) return;
+
     // Cancellation flag: if activeSemester changes while a fetch is in flight,
     // a slower earlier request must not overwrite the newer semester's rows.
     let cancelled = false;
@@ -602,7 +611,7 @@ export default function ScheduleContent() {
   // Show registration status for the newest term with available data. This can
   // be a future registration term, such as Fall 2026 while the calendar is still
   // in Summer 2026.
-  const isLatestAvailableSemester = activeSemester === latestAvailableSemester;
+  const isLatestAvailableSemester = activeSemester !== '' && activeSemester === latestAvailableSemester;
   const scheduleTableColumns = isLatestAvailableSemester ? currentScheduleTableColumns : historicalScheduleTableColumns;
 
   // Reusable table row renderer
@@ -852,6 +861,8 @@ export default function ScheduleContent() {
               label="Semester"
               data={semesters}
               value={activeSemester}
+              placeholder={isDiscoveringSemester ? 'Finding latest semester…' : undefined}
+              disabled={isDiscoveringSemester}
               onChange={(value) => {
                 userSelectedSemesterRef.current = true;
                 setActiveSemester(value || semesters[0]?.value || '');
@@ -902,7 +913,7 @@ export default function ScheduleContent() {
         <Group justify="space-between" mb="lg">
           <div>
             <Title order={2} size="h3">
-              {getTermLabel(activeSemester)} Courses
+              {activeSemester ? `${getTermLabel(activeSemester)} Courses` : 'Course Schedule'}
             </Title>
             <Group gap="xs">
               <Text size="sm" c="dimmed">
@@ -935,7 +946,9 @@ export default function ScheduleContent() {
             <Center h={300}>
               <Stack align="center" gap="md">
                 <Loader color={GT_COLORS.techGold} />
-                <Text c="dimmed" size="sm">Loading course data...</Text>
+                <Text c="dimmed" size="sm">
+                  {isDiscoveringSemester ? 'Finding latest semester…' : 'Loading course data...'}
+                </Text>
               </Stack>
             </Center>
           </Paper>


### PR DESCRIPTION
## Summary

- resolve the newest available semester before starting the schedule data request
- show a neutral discovery state instead of briefly selecting the calendar-current term
- fall back to the calendar-current semester when no future availability data exists
- add regression coverage for initialization and fallback behavior

## Root cause

The schedule initially selected the calendar-current semester, then asynchronously discovered and selected a newer registration term. That allowed Summer 2026 to render briefly before Fall 2026 replaced it.

## Impact

The schedule now loads directly into the newest semester with availability data and avoids the rapid semester label and data transition.

## Validation

- added schedule integration assertions for the unresolved and fallback states
- verified the PR diff is limited to the schedule component and its integration test
- verified the diff contains no whitespace errors or merge markers
